### PR TITLE
fixed interaction orders of couplings with dg1, dgw

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,7 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# other files
+UFO_models/int_order_bug_fix*
+UFO_models/*/restrict_c*

--- a/FeynRules_source/SMEFTsim_parameters.fr
+++ b/FeynRules_source/SMEFTsim_parameters.fr
@@ -396,11 +396,11 @@ alphaScheme,
 
     Switch[Flavor,
     general,
-    DG1order =   {{NP,1},{NPcHl3,1},{NPcll,1},{NPshifts,1}};
-    DGWorder =   {{NP,1},{NPcHWB,1},{NPcHDD,1},{NPcHl3,1},{NPcll,1},{NPshifts,1}};
+    DG1order =   {{NP,1},{NPcHWB,1},{NPcHDD,1},{NPcHl3,1},{NPcll,1},{NPshifts,1}};
+    DGWorder =   {{NP,1},{NPcHl3,1},{NPcll,1},{NPshifts,1}};
     ,_,
-    DG1order =   {{NP,1},{NPcHl3,1},{NPcll1,1},{NPshifts,1}};
-    DGWorder =   {{NP,1},{NPcHWB,1},{NPcHDD,1},{NPcHl3,1},{NPcll1,1},{NPshifts,1}}
+    DG1order =   {{NP,1},{NPcHWB,1},{NPcHDD,1},{NPcHl3,1},{NPcll1,1},{NPshifts,1}};
+    DGWorder =   {{NP,1},{NPcHl3,1},{NPcll1,1},{NPshifts,1}}
     ]
 
 ];

--- a/UFO_models/SMEFTsim_MFV_MwScheme_UFO_v3_0/couplings.py
+++ b/UFO_models/SMEFTsim_MFV_MwScheme_UFO_v3_0/couplings.py
@@ -27,19 +27,19 @@ GC_4 = Coupling(name = 'GC_4',
 
 GC_5 = Coupling(name = 'GC_5',
                 value = '(cth**2*dg1*ee*complex(0,1))/3.',
-                order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_6 = Coupling(name = 'GC_6',
                 value = '(-2*cth**2*dg1*ee*complex(0,1))/3.',
-                order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_7 = Coupling(name = 'GC_7',
                 value = '-(cth**2*dg1*ee*complex(0,1))',
-                order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_8 = Coupling(name = 'GC_8',
                 value = 'cth**2*dg1*ee*complex(0,1)',
-                order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_9 = Coupling(name = 'GC_9',
                 value = 'ee**2*complex(0,1)',
@@ -47,15 +47,15 @@ GC_9 = Coupling(name = 'GC_9',
 
 GC_10 = Coupling(name = 'GC_10',
                  value = '(dg1*ee**2*complex(0,1))/cth**2',
-                 order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':2})
+                 order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':2})
 
 GC_11 = Coupling(name = 'GC_11',
                  value = '-2*cth**2*dg1*ee**2*complex(0,1)',
-                 order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':2})
+                 order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':2})
 
 GC_12 = Coupling(name = 'GC_12',
                  value = '2*cth**2*dg1*ee**2*complex(0,1)',
-                 order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':2})
+                 order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':2})
 
 GC_13 = Coupling(name = 'GC_13',
                  value = '-(complex(0,1)*G)',
@@ -387,11 +387,11 @@ GC_94 = Coupling(name = 'GC_94',
 
 GC_95 = Coupling(name = 'GC_95',
                  value = '(dgw*ee**2*complex(0,1))/sth**2',
-                 order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':2})
+                 order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':2})
 
 GC_96 = Coupling(name = 'GC_96',
                  value = '(-2*dgw*ee**2*complex(0,1))/sth**2',
-                 order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':2})
+                 order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':2})
 
 GC_97 = Coupling(name = 'GC_97',
                  value = '(dkH*ee**2*complex(0,1))/sth**2',
@@ -543,55 +543,55 @@ GC_133 = Coupling(name = 'GC_133',
 
 GC_134 = Coupling(name = 'GC_134',
                   value = '-((dgw*ee*complex(0,1))/(sth*cmath.sqrt(2)))',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_135 = Coupling(name = 'GC_135',
                   value = '-((CKM1x1*dgw*ee*complex(0,1))/(sth*cmath.sqrt(2)))',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_136 = Coupling(name = 'GC_136',
                   value = '-((CKM1x2*dgw*ee*complex(0,1))/(sth*cmath.sqrt(2)))',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_137 = Coupling(name = 'GC_137',
                   value = '-((CKM1x3*dgw*ee*complex(0,1))/(sth*cmath.sqrt(2)))',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_138 = Coupling(name = 'GC_138',
                   value = '-((CKM2x1*dgw*ee*complex(0,1))/(sth*cmath.sqrt(2)))',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_139 = Coupling(name = 'GC_139',
                   value = '-((CKM2x2*dgw*ee*complex(0,1))/(sth*cmath.sqrt(2)))',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_140 = Coupling(name = 'GC_140',
                   value = '-((CKM2x3*dgw*ee*complex(0,1))/(sth*cmath.sqrt(2)))',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_141 = Coupling(name = 'GC_141',
                   value = '-((CKM3x1*dgw*ee*complex(0,1))/(sth*cmath.sqrt(2)))',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_142 = Coupling(name = 'GC_142',
                   value = '-((CKM3x2*dgw*ee*complex(0,1))/(sth*cmath.sqrt(2)))',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_143 = Coupling(name = 'GC_143',
                   value = '-((CKM3x3*dgw*ee*complex(0,1))/(sth*cmath.sqrt(2)))',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_144 = Coupling(name = 'GC_144',
                   value = '(dgw*ee*complex(0,1))/(2.*cth*sth)',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_145 = Coupling(name = 'GC_145',
                   value = '-(cth*dgw*ee*complex(0,1))/(2.*sth)',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_146 = Coupling(name = 'GC_146',
                   value = '(cth*dgw*ee*complex(0,1))/(2.*sth)',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_147 = Coupling(name = 'GC_147',
                   value = '(-2*cth*ee**2*complex(0,1))/sth',
@@ -811,35 +811,35 @@ GC_200 = Coupling(name = 'GC_200',
 
 GC_201 = Coupling(name = 'GC_201',
                   value = '-(dg1*ee*complex(0,1)*sth)/(6.*cth)',
-                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_202 = Coupling(name = 'GC_202',
                   value = '-(dg1*ee*complex(0,1)*sth)/(2.*cth)',
-                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_203 = Coupling(name = 'GC_203',
                   value = '(5*dg1*ee*complex(0,1)*sth)/(6.*cth)',
-                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_204 = Coupling(name = 'GC_204',
                   value = '(-3*dg1*ee*complex(0,1)*sth)/(2.*cth)',
-                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_205 = Coupling(name = 'GC_205',
                   value = 'cth*dg1*ee*complex(0,1)*sth',
-                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_206 = Coupling(name = 'GC_206',
                   value = '(dgw*ee*complex(0,1)*sth)/(2.*cth)',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_207 = Coupling(name = 'GC_207',
                   value = '(cth*dgw*ee*complex(0,1)*sth)/3.',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_208 = Coupling(name = 'GC_208',
                   value = '(-2*cth*dgw*ee*complex(0,1)*sth)/3.',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_209 = Coupling(name = 'GC_209',
                   value = '(-4*cHB*cth*complex(0,1)*sth)/LambdaSMEFT**2',
@@ -891,23 +891,23 @@ GC_220 = Coupling(name = 'GC_220',
 
 GC_221 = Coupling(name = 'GC_221',
                   value = '(dgw*ee*complex(0,1)*sth**2)/3.',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_222 = Coupling(name = 'GC_222',
                   value = '(-2*dgw*ee*complex(0,1)*sth**2)/3.',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_223 = Coupling(name = 'GC_223',
                   value = '-(dgw*ee*complex(0,1)*sth**2)',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_224 = Coupling(name = 'GC_224',
                   value = 'dgw*ee*complex(0,1)*sth**2',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_225 = Coupling(name = 'GC_225',
                   value = '2*dgw*ee**2*complex(0,1)*sth**2',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':2})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':2})
 
 GC_226 = Coupling(name = 'GC_226',
                   value = '(4*cHB*complex(0,1)*sth**2)/LambdaSMEFT**2',
@@ -919,35 +919,35 @@ GC_227 = Coupling(name = 'GC_227',
 
 GC_228 = Coupling(name = 'GC_228',
                   value = '(dg1*ee*complex(0,1)*sth**3)/(3.*cth)',
-                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_229 = Coupling(name = 'GC_229',
                   value = '(-2*dg1*ee*complex(0,1)*sth**3)/(3.*cth)',
-                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_230 = Coupling(name = 'GC_230',
                   value = '(dg1*ee*complex(0,1)*sth**3)/cth',
-                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_231 = Coupling(name = 'GC_231',
                   value = '-((dgw*ee*complex(0,1)*sth**3)/cth)',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_232 = Coupling(name = 'GC_232',
                   value = '-((cth*dgw*ee*complex(0,1))/sth) - cth*dgw*ee*complex(0,1)*sth',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_233 = Coupling(name = 'GC_233',
                   value = '(-2*cth*dg1*ee**2*complex(0,1))/sth + 4*cth*dg1*ee**2*complex(0,1)*sth',
-                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':2})
+                  order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':2})
 
 GC_234 = Coupling(name = 'GC_234',
                   value = '(-2*cth*dgw*ee**2*complex(0,1))/sth - 4*cth*dgw*ee**2*complex(0,1)*sth',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':2})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':2})
 
 GC_235 = Coupling(name = 'GC_235',
                   value = '(2*dgw*ee**2*complex(0,1))/sth**2 - 2*dgw*ee**2*complex(0,1)*sth**2',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':2})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':2})
 
 GC_236 = Coupling(name = 'GC_236',
                   value = '(-2*cHWB*complex(0,1))/LambdaSMEFT**2 + (4*cHWB*complex(0,1)*sth**2)/LambdaSMEFT**2',
@@ -1191,7 +1191,7 @@ GC_295 = Coupling(name = 'GC_295',
 
 GC_296 = Coupling(name = 'GC_296',
                   value = '(dgw*ee**2*complex(0,1)*vevhat)/sth**2',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_297 = Coupling(name = 'GC_297',
                   value = '(dkH*ee**2*complex(0,1)*vevhat)/(2.*sth**2)',
@@ -1502,7 +1502,11 @@ GC_373 = Coupling(name = 'GC_373',
                   order = {'NP':1,'NPcHWB':1,'QED':1})
 
 GC_374 = Coupling(name = 'GC_374',
-                  value = '(dg1*ee**2*complex(0,1)*vevhat)/cth**2 + (dGf*ee**2*complex(0,1)*vevhat)/(4.*cth**2*sth**2)',
+                  value = '(dg1*ee**2*complex(0,1)*vevhat)/cth**2',
+                  order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+
+GC_37400 = Coupling(name = 'GC_37400',
+                  value = '(dGf*ee**2*complex(0,1)*vevhat)/(4.*cth**2*sth**2)',
                   order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_375 = Coupling(name = 'GC_375',
@@ -4551,7 +4555,7 @@ GC_1135 = Coupling(name = 'GC_1135',
 
 GC_1136 = Coupling(name = 'GC_1136',
                    value = '-((dgw*ee*complex(0,1)*complexconjugate(CKM1x1))/(sth*cmath.sqrt(2)))',
-                   order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                   order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_1137 = Coupling(name = 'GC_1137',
                    value = '-((cHq30*ee*complex(0,1)*complexconjugate(CKM1x1)*cmath.sqrt(2))/(LambdaSMEFT**2*sth))',
@@ -5143,7 +5147,7 @@ GC_1283 = Coupling(name = 'GC_1283',
 
 GC_1284 = Coupling(name = 'GC_1284',
                    value = '-((dgw*ee*complex(0,1)*complexconjugate(CKM1x2))/(sth*cmath.sqrt(2)))',
-                   order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                   order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_1285 = Coupling(name = 'GC_1285',
                    value = '-((cHq30*ee*complex(0,1)*complexconjugate(CKM1x2)*cmath.sqrt(2))/(LambdaSMEFT**2*sth))',
@@ -5831,7 +5835,7 @@ GC_1455 = Coupling(name = 'GC_1455',
 
 GC_1456 = Coupling(name = 'GC_1456',
                    value = '-((dgw*ee*complex(0,1)*complexconjugate(CKM1x3))/(sth*cmath.sqrt(2)))',
-                   order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                   order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_1457 = Coupling(name = 'GC_1457',
                    value = '-((cHq30*ee*complex(0,1)*complexconjugate(CKM1x3)*cmath.sqrt(2))/(LambdaSMEFT**2*sth))',
@@ -7303,7 +7307,7 @@ GC_1823 = Coupling(name = 'GC_1823',
 
 GC_1824 = Coupling(name = 'GC_1824',
                    value = '-((dgw*ee*complex(0,1)*complexconjugate(CKM2x1))/(sth*cmath.sqrt(2)))',
-                   order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                   order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_1825 = Coupling(name = 'GC_1825',
                    value = '-((cHq30*ee*complex(0,1)*complexconjugate(CKM2x1)*cmath.sqrt(2))/(LambdaSMEFT**2*sth))',
@@ -7995,7 +7999,7 @@ GC_1996 = Coupling(name = 'GC_1996',
 
 GC_1997 = Coupling(name = 'GC_1997',
                    value = '-((dgw*ee*complex(0,1)*complexconjugate(CKM2x2))/(sth*cmath.sqrt(2)))',
-                   order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                   order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_1998 = Coupling(name = 'GC_1998',
                    value = '-((cHq30*ee*complex(0,1)*complexconjugate(CKM2x2)*cmath.sqrt(2))/(LambdaSMEFT**2*sth))',
@@ -8779,7 +8783,7 @@ GC_2192 = Coupling(name = 'GC_2192',
 
 GC_2193 = Coupling(name = 'GC_2193',
                    value = '-((dgw*ee*complex(0,1)*complexconjugate(CKM2x3))/(sth*cmath.sqrt(2)))',
-                   order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                   order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_2194 = Coupling(name = 'GC_2194',
                    value = '-((cHq30*ee*complex(0,1)*complexconjugate(CKM2x3)*cmath.sqrt(2))/(LambdaSMEFT**2*sth))',
@@ -10839,7 +10843,7 @@ GC_2707 = Coupling(name = 'GC_2707',
 
 GC_2708 = Coupling(name = 'GC_2708',
                    value = '-((dgw*ee*complex(0,1)*complexconjugate(CKM3x1))/(sth*cmath.sqrt(2)))',
-                   order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                   order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_2709 = Coupling(name = 'GC_2709',
                    value = '-((cHq30*ee*complex(0,1)*complexconjugate(CKM3x1)*cmath.sqrt(2))/(LambdaSMEFT**2*sth))',
@@ -12227,7 +12231,7 @@ GC_3054 = Coupling(name = 'GC_3054',
 
 GC_3055 = Coupling(name = 'GC_3055',
                    value = '-((dgw*ee*complex(0,1)*complexconjugate(CKM3x2))/(sth*cmath.sqrt(2)))',
-                   order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                   order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_3056 = Coupling(name = 'GC_3056',
                    value = '-((cHq30*ee*complex(0,1)*complexconjugate(CKM3x2)*cmath.sqrt(2))/(LambdaSMEFT**2*sth))',
@@ -13943,7 +13947,7 @@ GC_3483 = Coupling(name = 'GC_3483',
 
 GC_3484 = Coupling(name = 'GC_3484',
                    value = '-((dgw*ee*complex(0,1)*complexconjugate(CKM3x3))/(sth*cmath.sqrt(2)))',
-                   order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                   order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_3485 = Coupling(name = 'GC_3485',
                    value = '-((cHq30*ee*complex(0,1)*complexconjugate(CKM3x3)*cmath.sqrt(2))/(LambdaSMEFT**2*sth))',

--- a/UFO_models/SMEFTsim_MFV_MwScheme_UFO_v3_0/vertices.py
+++ b/UFO_models/SMEFTsim_MFV_MwScheme_UFO_v3_0/vertices.py
@@ -465,6 +465,12 @@ V_76 = Vertex(name = 'V_76',
               lorentz = [ L.VVS1, L.VVS2 ],
               couplings = {(0,1):C.GC_284,(0,0):C.GC_374})
 
+V_7600 = Vertex(name = 'V_7600',
+              particles = [ P.Z, P.Z, P.H ],
+              color = [ '1' ],
+              lorentz = [ L.VVS1 ],
+              couplings = {(0,0):C.GC_37400})
+
 V_77 = Vertex(name = 'V_77',
               particles = [ P.Z, P.Z, P.H ],
               color = [ '1' ],

--- a/UFO_models/SMEFTsim_U35_MwScheme_UFO_v3_0/couplings.py
+++ b/UFO_models/SMEFTsim_U35_MwScheme_UFO_v3_0/couplings.py
@@ -27,19 +27,19 @@ GC_4 = Coupling(name = 'GC_4',
 
 GC_5 = Coupling(name = 'GC_5',
                 value = '(cth**2*dg1*ee*complex(0,1))/3.',
-                order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_6 = Coupling(name = 'GC_6',
                 value = '(-2*cth**2*dg1*ee*complex(0,1))/3.',
-                order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_7 = Coupling(name = 'GC_7',
                 value = '-(cth**2*dg1*ee*complex(0,1))',
-                order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_8 = Coupling(name = 'GC_8',
                 value = 'cth**2*dg1*ee*complex(0,1)',
-                order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_9 = Coupling(name = 'GC_9',
                 value = 'ee**2*complex(0,1)',
@@ -47,15 +47,15 @@ GC_9 = Coupling(name = 'GC_9',
 
 GC_10 = Coupling(name = 'GC_10',
                  value = '(dg1*ee**2*complex(0,1))/cth**2',
-                 order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':2})
+                 order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':2})
 
 GC_11 = Coupling(name = 'GC_11',
                  value = '-2*cth**2*dg1*ee**2*complex(0,1)',
-                 order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':2})
+                 order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':2})
 
 GC_12 = Coupling(name = 'GC_12',
                  value = '2*cth**2*dg1*ee**2*complex(0,1)',
-                 order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':2})
+                 order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':2})
 
 GC_13 = Coupling(name = 'GC_13',
                  value = '-(complex(0,1)*G)',
@@ -451,11 +451,11 @@ GC_110 = Coupling(name = 'GC_110',
 
 GC_111 = Coupling(name = 'GC_111',
                   value = '(dgw*ee**2*complex(0,1))/sth**2',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':2})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':2})
 
 GC_112 = Coupling(name = 'GC_112',
                   value = '(-2*dgw*ee**2*complex(0,1))/sth**2',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':2})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':2})
 
 GC_113 = Coupling(name = 'GC_113',
                   value = '(dkH*ee**2*complex(0,1))/sth**2',
@@ -615,55 +615,55 @@ GC_151 = Coupling(name = 'GC_151',
 
 GC_152 = Coupling(name = 'GC_152',
                   value = '-((dgw*ee*complex(0,1))/(sth*cmath.sqrt(2)))',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_153 = Coupling(name = 'GC_153',
                   value = '-((CKM1x1*dgw*ee*complex(0,1))/(sth*cmath.sqrt(2)))',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_154 = Coupling(name = 'GC_154',
                   value = '-((CKM1x2*dgw*ee*complex(0,1))/(sth*cmath.sqrt(2)))',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_155 = Coupling(name = 'GC_155',
                   value = '-((CKM1x3*dgw*ee*complex(0,1))/(sth*cmath.sqrt(2)))',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_156 = Coupling(name = 'GC_156',
                   value = '-((CKM2x1*dgw*ee*complex(0,1))/(sth*cmath.sqrt(2)))',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_157 = Coupling(name = 'GC_157',
                   value = '-((CKM2x2*dgw*ee*complex(0,1))/(sth*cmath.sqrt(2)))',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_158 = Coupling(name = 'GC_158',
                   value = '-((CKM2x3*dgw*ee*complex(0,1))/(sth*cmath.sqrt(2)))',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_159 = Coupling(name = 'GC_159',
                   value = '-((CKM3x1*dgw*ee*complex(0,1))/(sth*cmath.sqrt(2)))',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_160 = Coupling(name = 'GC_160',
                   value = '-((CKM3x2*dgw*ee*complex(0,1))/(sth*cmath.sqrt(2)))',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_161 = Coupling(name = 'GC_161',
                   value = '-((CKM3x3*dgw*ee*complex(0,1))/(sth*cmath.sqrt(2)))',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_162 = Coupling(name = 'GC_162',
                   value = '-(dgw*ee*complex(0,1))/(2.*cth*sth)',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_163 = Coupling(name = 'GC_163',
                   value = '(dgw*ee*complex(0,1))/(2.*cth*sth)',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_164 = Coupling(name = 'GC_164',
                   value = '-(cth*dgw*ee*complex(0,1))/(2.*sth)',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_165 = Coupling(name = 'GC_165',
                   value = '(-2*cth*ee**2*complex(0,1))/sth',
@@ -907,31 +907,31 @@ GC_224 = Coupling(name = 'GC_224',
 
 GC_225 = Coupling(name = 'GC_225',
                   value = '-(dg1*ee*complex(0,1)*sth)/(6.*cth)',
-                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_226 = Coupling(name = 'GC_226',
                   value = '-(dg1*ee*complex(0,1)*sth)/(2.*cth)',
-                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_227 = Coupling(name = 'GC_227',
                   value = '(5*dg1*ee*complex(0,1)*sth)/(6.*cth)',
-                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_228 = Coupling(name = 'GC_228',
                   value = '(-3*dg1*ee*complex(0,1)*sth)/(2.*cth)',
-                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_229 = Coupling(name = 'GC_229',
                   value = 'cth*dg1*ee*complex(0,1)*sth',
-                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_230 = Coupling(name = 'GC_230',
                   value = '-(dgw*ee*complex(0,1)*sth)/(6.*cth)',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_231 = Coupling(name = 'GC_231',
                   value = '(dgw*ee*complex(0,1)*sth)/(2.*cth)',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_232 = Coupling(name = 'GC_232',
                   value = '(-4*cHB*cth*complex(0,1)*sth)/LambdaSMEFT**2',
@@ -1011,23 +1011,23 @@ GC_250 = Coupling(name = 'GC_250',
 
 GC_251 = Coupling(name = 'GC_251',
                   value = '(dgw*ee*complex(0,1)*sth**2)/3.',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_252 = Coupling(name = 'GC_252',
                   value = '(-2*dgw*ee*complex(0,1)*sth**2)/3.',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_253 = Coupling(name = 'GC_253',
                   value = '-(dgw*ee*complex(0,1)*sth**2)',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_254 = Coupling(name = 'GC_254',
                   value = 'dgw*ee*complex(0,1)*sth**2',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_255 = Coupling(name = 'GC_255',
                   value = '2*dgw*ee**2*complex(0,1)*sth**2',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':2})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':2})
 
 GC_256 = Coupling(name = 'GC_256',
                   value = '(4*cHB*complex(0,1)*sth**2)/LambdaSMEFT**2',
@@ -1047,43 +1047,43 @@ GC_259 = Coupling(name = 'GC_259',
 
 GC_260 = Coupling(name = 'GC_260',
                   value = '(dg1*ee*complex(0,1)*sth**3)/(3.*cth)',
-                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_261 = Coupling(name = 'GC_261',
                   value = '(-2*dg1*ee*complex(0,1)*sth**3)/(3.*cth)',
-                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_262 = Coupling(name = 'GC_262',
                   value = '(dg1*ee*complex(0,1)*sth**3)/cth',
-                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_263 = Coupling(name = 'GC_263',
                   value = '-(dgw*ee*complex(0,1)*sth**3)/(3.*cth)',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_264 = Coupling(name = 'GC_264',
                   value = '(2*dgw*ee*complex(0,1)*sth**3)/(3.*cth)',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_265 = Coupling(name = 'GC_265',
                   value = '-((dgw*ee*complex(0,1)*sth**3)/cth)',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_266 = Coupling(name = 'GC_266',
                   value = '-((cth*dgw*ee*complex(0,1))/sth) - cth*dgw*ee*complex(0,1)*sth',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_267 = Coupling(name = 'GC_267',
                   value = '(-2*cth*dg1*ee**2*complex(0,1))/sth + 4*cth*dg1*ee**2*complex(0,1)*sth',
-                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':2})
+                  order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':2})
 
 GC_268 = Coupling(name = 'GC_268',
                   value = '(-2*cth*dgw*ee**2*complex(0,1))/sth - 4*cth*dgw*ee**2*complex(0,1)*sth',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':2})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':2})
 
 GC_269 = Coupling(name = 'GC_269',
                   value = '(2*dgw*ee**2*complex(0,1))/sth**2 - 2*dgw*ee**2*complex(0,1)*sth**2',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':2})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':2})
 
 GC_270 = Coupling(name = 'GC_270',
                   value = '(-2*cHWB*complex(0,1))/LambdaSMEFT**2 + (4*cHWB*complex(0,1)*sth**2)/LambdaSMEFT**2',
@@ -1359,7 +1359,7 @@ GC_337 = Coupling(name = 'GC_337',
 
 GC_338 = Coupling(name = 'GC_338',
                   value = '(dgw*ee**2*complex(0,1)*vevhat)/sth**2',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_339 = Coupling(name = 'GC_339',
                   value = '(dkH*ee**2*complex(0,1)*vevhat)/(2.*sth**2)',
@@ -1722,8 +1722,12 @@ GC_428 = Coupling(name = 'GC_428',
                   order = {'NP':1,'NPcHWB':1,'QED':1})
 
 GC_429 = Coupling(name = 'GC_429',
-                  value = '(dg1*ee**2*complex(0,1)*vevhat)/cth**2 + (dGf*ee**2*complex(0,1)*vevhat)/(4.*cth**2*sth**2)',
-                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  value = '(dg1*ee**2*complex(0,1)*vevhat)/cth**2',
+                  order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+
+GC_42900 = Coupling(name = 'GC_42900',
+                    value = '(dGf*ee**2*complex(0,1)*vevhat)/(4.*cth**2*sth**2)',
+                    order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_430 = Coupling(name = 'GC_430',
                   value = '(-2*cHWB*complex(0,1)*vevhat)/LambdaSMEFT**2 + (4*cHWB*complex(0,1)*sth**2*vevhat)/LambdaSMEFT**2',
@@ -5727,7 +5731,7 @@ GC_1429 = Coupling(name = 'GC_1429',
 
 GC_1430 = Coupling(name = 'GC_1430',
                    value = '-((dgw*ee*complex(0,1)*complexconjugate(CKM1x1))/(sth*cmath.sqrt(2)))',
-                   order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                   order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_1431 = Coupling(name = 'GC_1431',
                    value = '-((cHq3*ee*complex(0,1)*complexconjugate(CKM1x1)*cmath.sqrt(2))/(LambdaSMEFT**2*sth))',
@@ -6543,7 +6547,7 @@ GC_1633 = Coupling(name = 'GC_1633',
 
 GC_1634 = Coupling(name = 'GC_1634',
                    value = '-((dgw*ee*complex(0,1)*complexconjugate(CKM1x2))/(sth*cmath.sqrt(2)))',
-                   order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                   order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_1635 = Coupling(name = 'GC_1635',
                    value = '-((cHq3*ee*complex(0,1)*complexconjugate(CKM1x2)*cmath.sqrt(2))/(LambdaSMEFT**2*sth))',
@@ -7359,7 +7363,7 @@ GC_1837 = Coupling(name = 'GC_1837',
 
 GC_1838 = Coupling(name = 'GC_1838',
                    value = '-((dgw*ee*complex(0,1)*complexconjugate(CKM1x3))/(sth*cmath.sqrt(2)))',
-                   order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                   order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_1839 = Coupling(name = 'GC_1839',
                    value = '-((cHq3*ee*complex(0,1)*complexconjugate(CKM1x3)*cmath.sqrt(2))/(LambdaSMEFT**2*sth))',
@@ -8175,7 +8179,7 @@ GC_2041 = Coupling(name = 'GC_2041',
 
 GC_2042 = Coupling(name = 'GC_2042',
                    value = '-((dgw*ee*complex(0,1)*complexconjugate(CKM2x1))/(sth*cmath.sqrt(2)))',
-                   order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                   order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_2043 = Coupling(name = 'GC_2043',
                    value = '-((cHq3*ee*complex(0,1)*complexconjugate(CKM2x1)*cmath.sqrt(2))/(LambdaSMEFT**2*sth))',
@@ -8991,7 +8995,7 @@ GC_2245 = Coupling(name = 'GC_2245',
 
 GC_2246 = Coupling(name = 'GC_2246',
                    value = '-((dgw*ee*complex(0,1)*complexconjugate(CKM2x2))/(sth*cmath.sqrt(2)))',
-                   order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                   order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_2247 = Coupling(name = 'GC_2247',
                    value = '-((cHq3*ee*complex(0,1)*complexconjugate(CKM2x2)*cmath.sqrt(2))/(LambdaSMEFT**2*sth))',
@@ -9807,7 +9811,7 @@ GC_2449 = Coupling(name = 'GC_2449',
 
 GC_2450 = Coupling(name = 'GC_2450',
                    value = '-((dgw*ee*complex(0,1)*complexconjugate(CKM2x3))/(sth*cmath.sqrt(2)))',
-                   order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                   order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_2451 = Coupling(name = 'GC_2451',
                    value = '-((cHq3*ee*complex(0,1)*complexconjugate(CKM2x3)*cmath.sqrt(2))/(LambdaSMEFT**2*sth))',
@@ -10623,7 +10627,7 @@ GC_2653 = Coupling(name = 'GC_2653',
 
 GC_2654 = Coupling(name = 'GC_2654',
                    value = '-((dgw*ee*complex(0,1)*complexconjugate(CKM3x1))/(sth*cmath.sqrt(2)))',
-                   order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                   order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_2655 = Coupling(name = 'GC_2655',
                    value = '-((cHq3*ee*complex(0,1)*complexconjugate(CKM3x1)*cmath.sqrt(2))/(LambdaSMEFT**2*sth))',
@@ -11443,7 +11447,7 @@ GC_2858 = Coupling(name = 'GC_2858',
 
 GC_2859 = Coupling(name = 'GC_2859',
                    value = '-((dgw*ee*complex(0,1)*complexconjugate(CKM3x2))/(sth*cmath.sqrt(2)))',
-                   order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                   order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_2860 = Coupling(name = 'GC_2860',
                    value = '-((cHq3*ee*complex(0,1)*complexconjugate(CKM3x2)*cmath.sqrt(2))/(LambdaSMEFT**2*sth))',
@@ -12263,7 +12267,7 @@ GC_3063 = Coupling(name = 'GC_3063',
 
 GC_3064 = Coupling(name = 'GC_3064',
                    value = '-((dgw*ee*complex(0,1)*complexconjugate(CKM3x3))/(sth*cmath.sqrt(2)))',
-                   order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                   order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_3065 = Coupling(name = 'GC_3065',
                    value = '-((cHq3*ee*complex(0,1)*complexconjugate(CKM3x3)*cmath.sqrt(2))/(LambdaSMEFT**2*sth))',

--- a/UFO_models/SMEFTsim_U35_MwScheme_UFO_v3_0/vertices.py
+++ b/UFO_models/SMEFTsim_U35_MwScheme_UFO_v3_0/vertices.py
@@ -393,6 +393,12 @@ V_64 = Vertex(name = 'V_64',
               lorentz = [ L.VVS2, L.VVS3, L.VVS4 ],
               couplings = {(0,0):C.GC_323,(0,2):C.GC_322,(0,1):C.GC_429})
 
+V_6400 = Vertex(name = 'V_6400',
+              particles = [ P.Z, P.Z, P.H ],
+              color = [ '1' ],
+              lorentz = [ L.VVS3 ],
+              couplings = {(0,0):C.GC_42900})
+
 V_65 = Vertex(name = 'V_65',
               particles = [ P.Z, P.Z, P.H ],
               color = [ '1' ],

--- a/UFO_models/SMEFTsim_general_MwScheme_UFO_v3_0/couplings.py
+++ b/UFO_models/SMEFTsim_general_MwScheme_UFO_v3_0/couplings.py
@@ -27,19 +27,19 @@ GC_4 = Coupling(name = 'GC_4',
 
 GC_5 = Coupling(name = 'GC_5',
                 value = '(cth**2*dg1*ee*complex(0,1))/3.',
-                order = {'NP':1,'NPcHl3':1,'NPcll':1,'NPshifts':1,'QED':1})
+                order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll':1,'NPshifts':1,'QED':1})
 
 GC_6 = Coupling(name = 'GC_6',
                 value = '(-2*cth**2*dg1*ee*complex(0,1))/3.',
-                order = {'NP':1,'NPcHl3':1,'NPcll':1,'NPshifts':1,'QED':1})
+                order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll':1,'NPshifts':1,'QED':1})
 
 GC_7 = Coupling(name = 'GC_7',
                 value = '-(cth**2*dg1*ee*complex(0,1))',
-                order = {'NP':1,'NPcHl3':1,'NPcll':1,'NPshifts':1,'QED':1})
+                order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll':1,'NPshifts':1,'QED':1})
 
 GC_8 = Coupling(name = 'GC_8',
                 value = 'cth**2*dg1*ee*complex(0,1)',
-                order = {'NP':1,'NPcHl3':1,'NPcll':1,'NPshifts':1,'QED':1})
+                order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll':1,'NPshifts':1,'QED':1})
 
 GC_9 = Coupling(name = 'GC_9',
                 value = 'ee**2*complex(0,1)',
@@ -47,15 +47,15 @@ GC_9 = Coupling(name = 'GC_9',
 
 GC_10 = Coupling(name = 'GC_10',
                  value = '(dg1*ee**2*complex(0,1))/cth**2',
-                 order = {'NP':1,'NPcHl3':1,'NPcll':1,'NPshifts':1,'QED':2})
+                 order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll':1,'NPshifts':1,'QED':2})
 
 GC_11 = Coupling(name = 'GC_11',
                  value = '-2*cth**2*dg1*ee**2*complex(0,1)',
-                 order = {'NP':1,'NPcHl3':1,'NPcll':1,'NPshifts':1,'QED':2})
+                 order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll':1,'NPshifts':1,'QED':2})
 
 GC_12 = Coupling(name = 'GC_12',
                  value = '2*cth**2*dg1*ee**2*complex(0,1)',
-                 order = {'NP':1,'NPcHl3':1,'NPcll':1,'NPshifts':1,'QED':2})
+                 order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll':1,'NPshifts':1,'QED':2})
 
 GC_13 = Coupling(name = 'GC_13',
                  value = '-(complex(0,1)*G)',
@@ -23547,11 +23547,11 @@ GC_5884 = Coupling(name = 'GC_5884',
 
 GC_5885 = Coupling(name = 'GC_5885',
                    value = '(dgw*ee**2*complex(0,1))/sth**2',
-                   order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll':1,'NPshifts':1,'QED':2})
+                   order = {'NP':1,'NPcHl3':1,'NPcll':1,'NPshifts':1,'QED':2})
 
 GC_5886 = Coupling(name = 'GC_5886',
                    value = '(-2*dgw*ee**2*complex(0,1))/sth**2',
-                   order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll':1,'NPshifts':1,'QED':2})
+                   order = {'NP':1,'NPcHl3':1,'NPcll':1,'NPshifts':1,'QED':2})
 
 GC_5887 = Coupling(name = 'GC_5887',
                    value = '(dkH*ee**2*complex(0,1))/sth**2',
@@ -23711,55 +23711,55 @@ GC_5925 = Coupling(name = 'GC_5925',
 
 GC_5926 = Coupling(name = 'GC_5926',
                    value = '-((dgw*ee*complex(0,1))/(sth*cmath.sqrt(2)))',
-                   order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll':1,'NPshifts':1,'QED':1})
+                   order = {'NP':1,'NPcHl3':1,'NPcll':1,'NPshifts':1,'QED':1})
 
 GC_5927 = Coupling(name = 'GC_5927',
                    value = '-((CKM1x1*dgw*ee*complex(0,1))/(sth*cmath.sqrt(2)))',
-                   order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll':1,'NPshifts':1,'QED':1})
+                   order = {'NP':1,'NPcHl3':1,'NPcll':1,'NPshifts':1,'QED':1})
 
 GC_5928 = Coupling(name = 'GC_5928',
                    value = '-((CKM1x2*dgw*ee*complex(0,1))/(sth*cmath.sqrt(2)))',
-                   order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll':1,'NPshifts':1,'QED':1})
+                   order = {'NP':1,'NPcHl3':1,'NPcll':1,'NPshifts':1,'QED':1})
 
 GC_5929 = Coupling(name = 'GC_5929',
                    value = '-((CKM1x3*dgw*ee*complex(0,1))/(sth*cmath.sqrt(2)))',
-                   order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll':1,'NPshifts':1,'QED':1})
+                   order = {'NP':1,'NPcHl3':1,'NPcll':1,'NPshifts':1,'QED':1})
 
 GC_5930 = Coupling(name = 'GC_5930',
                    value = '-((CKM2x1*dgw*ee*complex(0,1))/(sth*cmath.sqrt(2)))',
-                   order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll':1,'NPshifts':1,'QED':1})
+                   order = {'NP':1,'NPcHl3':1,'NPcll':1,'NPshifts':1,'QED':1})
 
 GC_5931 = Coupling(name = 'GC_5931',
                    value = '-((CKM2x2*dgw*ee*complex(0,1))/(sth*cmath.sqrt(2)))',
-                   order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll':1,'NPshifts':1,'QED':1})
+                   order = {'NP':1,'NPcHl3':1,'NPcll':1,'NPshifts':1,'QED':1})
 
 GC_5932 = Coupling(name = 'GC_5932',
                    value = '-((CKM2x3*dgw*ee*complex(0,1))/(sth*cmath.sqrt(2)))',
-                   order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll':1,'NPshifts':1,'QED':1})
+                   order = {'NP':1,'NPcHl3':1,'NPcll':1,'NPshifts':1,'QED':1})
 
 GC_5933 = Coupling(name = 'GC_5933',
                    value = '-((CKM3x1*dgw*ee*complex(0,1))/(sth*cmath.sqrt(2)))',
-                   order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll':1,'NPshifts':1,'QED':1})
+                   order = {'NP':1,'NPcHl3':1,'NPcll':1,'NPshifts':1,'QED':1})
 
 GC_5934 = Coupling(name = 'GC_5934',
                    value = '-((CKM3x2*dgw*ee*complex(0,1))/(sth*cmath.sqrt(2)))',
-                   order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll':1,'NPshifts':1,'QED':1})
+                   order = {'NP':1,'NPcHl3':1,'NPcll':1,'NPshifts':1,'QED':1})
 
 GC_5935 = Coupling(name = 'GC_5935',
                    value = '-((CKM3x3*dgw*ee*complex(0,1))/(sth*cmath.sqrt(2)))',
-                   order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll':1,'NPshifts':1,'QED':1})
+                   order = {'NP':1,'NPcHl3':1,'NPcll':1,'NPshifts':1,'QED':1})
 
 GC_5936 = Coupling(name = 'GC_5936',
                    value = '-(dgw*ee*complex(0,1))/(2.*cth*sth)',
-                   order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll':1,'NPshifts':1,'QED':1})
+                   order = {'NP':1,'NPcHl3':1,'NPcll':1,'NPshifts':1,'QED':1})
 
 GC_5937 = Coupling(name = 'GC_5937',
                    value = '(dgw*ee*complex(0,1))/(2.*cth*sth)',
-                   order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll':1,'NPshifts':1,'QED':1})
+                   order = {'NP':1,'NPcHl3':1,'NPcll':1,'NPshifts':1,'QED':1})
 
 GC_5938 = Coupling(name = 'GC_5938',
                    value = '-(cth*dgw*ee*complex(0,1))/(2.*sth)',
-                   order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll':1,'NPshifts':1,'QED':1})
+                   order = {'NP':1,'NPcHl3':1,'NPcll':1,'NPshifts':1,'QED':1})
 
 GC_5939 = Coupling(name = 'GC_5939',
                    value = '(-2*cth*ee**2*complex(0,1))/sth',
@@ -24867,31 +24867,31 @@ GC_6214 = Coupling(name = 'GC_6214',
 
 GC_6215 = Coupling(name = 'GC_6215',
                    value = '-(dg1*ee*complex(0,1)*sth)/(6.*cth)',
-                   order = {'NP':1,'NPcHl3':1,'NPcll':1,'NPshifts':1,'QED':1})
+                   order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll':1,'NPshifts':1,'QED':1})
 
 GC_6216 = Coupling(name = 'GC_6216',
                    value = '-(dg1*ee*complex(0,1)*sth)/(2.*cth)',
-                   order = {'NP':1,'NPcHl3':1,'NPcll':1,'NPshifts':1,'QED':1})
+                   order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll':1,'NPshifts':1,'QED':1})
 
 GC_6217 = Coupling(name = 'GC_6217',
                    value = '(5*dg1*ee*complex(0,1)*sth)/(6.*cth)',
-                   order = {'NP':1,'NPcHl3':1,'NPcll':1,'NPshifts':1,'QED':1})
+                   order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll':1,'NPshifts':1,'QED':1})
 
 GC_6218 = Coupling(name = 'GC_6218',
                    value = '(-3*dg1*ee*complex(0,1)*sth)/(2.*cth)',
-                   order = {'NP':1,'NPcHl3':1,'NPcll':1,'NPshifts':1,'QED':1})
+                   order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll':1,'NPshifts':1,'QED':1})
 
 GC_6219 = Coupling(name = 'GC_6219',
                    value = 'cth*dg1*ee*complex(0,1)*sth',
-                   order = {'NP':1,'NPcHl3':1,'NPcll':1,'NPshifts':1,'QED':1})
+                   order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll':1,'NPshifts':1,'QED':1})
 
 GC_6220 = Coupling(name = 'GC_6220',
                    value = '-(dgw*ee*complex(0,1)*sth)/(6.*cth)',
-                   order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll':1,'NPshifts':1,'QED':1})
+                   order = {'NP':1,'NPcHl3':1,'NPcll':1,'NPshifts':1,'QED':1})
 
 GC_6221 = Coupling(name = 'GC_6221',
                    value = '(dgw*ee*complex(0,1)*sth)/(2.*cth)',
-                   order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll':1,'NPshifts':1,'QED':1})
+                   order = {'NP':1,'NPcHl3':1,'NPcll':1,'NPshifts':1,'QED':1})
 
 GC_6222 = Coupling(name = 'GC_6222',
                    value = '(ceBIm11*sth)/(LambdaSMEFT**2*cmath.sqrt(2))',
@@ -25387,23 +25387,23 @@ GC_6344 = Coupling(name = 'GC_6344',
 
 GC_6345 = Coupling(name = 'GC_6345',
                    value = '(dgw*ee*complex(0,1)*sth**2)/3.',
-                   order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll':1,'NPshifts':1,'QED':1})
+                   order = {'NP':1,'NPcHl3':1,'NPcll':1,'NPshifts':1,'QED':1})
 
 GC_6346 = Coupling(name = 'GC_6346',
                    value = '(-2*dgw*ee*complex(0,1)*sth**2)/3.',
-                   order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll':1,'NPshifts':1,'QED':1})
+                   order = {'NP':1,'NPcHl3':1,'NPcll':1,'NPshifts':1,'QED':1})
 
 GC_6347 = Coupling(name = 'GC_6347',
                    value = '-(dgw*ee*complex(0,1)*sth**2)',
-                   order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll':1,'NPshifts':1,'QED':1})
+                   order = {'NP':1,'NPcHl3':1,'NPcll':1,'NPshifts':1,'QED':1})
 
 GC_6348 = Coupling(name = 'GC_6348',
                    value = 'dgw*ee*complex(0,1)*sth**2',
-                   order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll':1,'NPshifts':1,'QED':1})
+                   order = {'NP':1,'NPcHl3':1,'NPcll':1,'NPshifts':1,'QED':1})
 
 GC_6349 = Coupling(name = 'GC_6349',
                    value = '2*dgw*ee**2*complex(0,1)*sth**2',
-                   order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll':1,'NPshifts':1,'QED':2})
+                   order = {'NP':1,'NPcHl3':1,'NPcll':1,'NPshifts':1,'QED':2})
 
 GC_6350 = Coupling(name = 'GC_6350',
                    value = '(4*cHB*complex(0,1)*sth**2)/LambdaSMEFT**2',
@@ -25423,39 +25423,39 @@ GC_6353 = Coupling(name = 'GC_6353',
 
 GC_6354 = Coupling(name = 'GC_6354',
                    value = '(dg1*ee*complex(0,1)*sth**3)/(3.*cth)',
-                   order = {'NP':1,'NPcHl3':1,'NPcll':1,'NPshifts':1,'QED':1})
+                   order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll':1,'NPshifts':1,'QED':1})
 
 GC_6355 = Coupling(name = 'GC_6355',
                    value = '(-2*dg1*ee*complex(0,1)*sth**3)/(3.*cth)',
-                   order = {'NP':1,'NPcHl3':1,'NPcll':1,'NPshifts':1,'QED':1})
+                   order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll':1,'NPshifts':1,'QED':1})
 
 GC_6356 = Coupling(name = 'GC_6356',
                    value = '(dg1*ee*complex(0,1)*sth**3)/cth',
-                   order = {'NP':1,'NPcHl3':1,'NPcll':1,'NPshifts':1,'QED':1})
+                   order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll':1,'NPshifts':1,'QED':1})
 
 GC_6357 = Coupling(name = 'GC_6357',
                    value = '-(dgw*ee*complex(0,1)*sth**3)/(3.*cth)',
-                   order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll':1,'NPshifts':1,'QED':1})
+                   order = {'NP':1,'NPcHl3':1,'NPcll':1,'NPshifts':1,'QED':1})
 
 GC_6358 = Coupling(name = 'GC_6358',
                    value = '(2*dgw*ee*complex(0,1)*sth**3)/(3.*cth)',
-                   order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll':1,'NPshifts':1,'QED':1})
+                   order = {'NP':1,'NPcHl3':1,'NPcll':1,'NPshifts':1,'QED':1})
 
 GC_6359 = Coupling(name = 'GC_6359',
                    value = '-((dgw*ee*complex(0,1)*sth**3)/cth)',
-                   order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll':1,'NPshifts':1,'QED':1})
+                   order = {'NP':1,'NPcHl3':1,'NPcll':1,'NPshifts':1,'QED':1})
 
 GC_6360 = Coupling(name = 'GC_6360',
                    value = '-((cth*dgw*ee*complex(0,1))/sth) - cth*dgw*ee*complex(0,1)*sth',
-                   order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll':1,'NPshifts':1,'QED':1})
+                   order = {'NP':1,'NPcHl3':1,'NPcll':1,'NPshifts':1,'QED':1})
 
 GC_6361 = Coupling(name = 'GC_6361',
                    value = '(-2*cth*dg1*ee**2*complex(0,1))/sth + 4*cth*dg1*ee**2*complex(0,1)*sth',
-                   order = {'NP':1,'NPcHl3':1,'NPcll':1,'NPshifts':1,'QED':2})
+                   order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll':1,'NPshifts':1,'QED':2})
 
 GC_6362 = Coupling(name = 'GC_6362',
                    value = '(-2*cth*dgw*ee**2*complex(0,1))/sth - 4*cth*dgw*ee**2*complex(0,1)*sth',
-                   order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll':1,'NPshifts':1,'QED':2})
+                   order = {'NP':1,'NPcHl3':1,'NPcll':1,'NPshifts':1,'QED':2})
 
 GC_6363 = Coupling(name = 'GC_6363',
                    value = '(cdBIm11*CKM1x1*sth)/(LambdaSMEFT**2*cmath.sqrt(2)) + (cdBIm21*CKM2x1*sth)/(LambdaSMEFT**2*cmath.sqrt(2))',
@@ -25619,7 +25619,7 @@ GC_6402 = Coupling(name = 'GC_6402',
 
 GC_6403 = Coupling(name = 'GC_6403',
                    value = '(2*dgw*ee**2*complex(0,1))/sth**2 - 2*dgw*ee**2*complex(0,1)*sth**2',
-                   order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll':1,'NPshifts':1,'QED':2})
+                   order = {'NP':1,'NPcHl3':1,'NPcll':1,'NPshifts':1,'QED':2})
 
 GC_6404 = Coupling(name = 'GC_6404',
                    value = '(-2*cHWB*complex(0,1))/LambdaSMEFT**2 + (4*cHWB*complex(0,1)*sth**2)/LambdaSMEFT**2',
@@ -27175,7 +27175,7 @@ GC_6791 = Coupling(name = 'GC_6791',
 
 GC_6792 = Coupling(name = 'GC_6792',
                    value = '(dgw*ee**2*complex(0,1)*vevhat)/sth**2',
-                   order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll':1,'NPshifts':1,'QED':1})
+                   order = {'NP':1,'NPcHl3':1,'NPcll':1,'NPshifts':1,'QED':1})
 
 GC_6793 = Coupling(name = 'GC_6793',
                    value = '(dkH*ee**2*complex(0,1)*vevhat)/(2.*sth**2)',
@@ -30042,7 +30042,11 @@ GC_7508 = Coupling(name = 'GC_7508',
                    order = {'NP':1,'NPcdG':1,'QCD':1,'QED':1})
 
 GC_7509 = Coupling(name = 'GC_7509',
-                   value = '(dg1*ee**2*complex(0,1)*vevhat)/cth**2 + (dGf*ee**2*complex(0,1)*vevhat)/(4.*cth**2*sth**2)',
+                   value = '(dg1*ee**2*complex(0,1)*vevhat)/cth**2',
+                   order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll':1,'NPshifts':1,'QED':1})
+
+GC_750900 = Coupling(name = 'GC_750900',
+                   value = '(dGf*ee**2*complex(0,1)*vevhat)/(4.*cth**2*sth**2)',
                    order = {'NP':1,'NPcHl3':1,'NPcll':1,'NPshifts':1,'QED':1})
 
 GC_7510 = Coupling(name = 'GC_7510',
@@ -30923,7 +30927,7 @@ GC_7728 = Coupling(name = 'GC_7728',
 
 GC_7729 = Coupling(name = 'GC_7729',
                    value = '-((dgw*ee*complex(0,1)*complexconjugate(CKM1x3))/(sth*cmath.sqrt(2)))',
-                   order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll':1,'NPshifts':1,'QED':1})
+                   order = {'NP':1,'NPcHl3':1,'NPcll':1,'NPshifts':1,'QED':1})
 
 GC_7730 = Coupling(name = 'GC_7730',
                    value = '-((cdWIm13*ee*complexconjugate(CKM1x3))/(LambdaSMEFT**2*sth*cmath.sqrt(2)))',
@@ -35799,7 +35803,7 @@ GC_8947 = Coupling(name = 'GC_8947',
 
 GC_8948 = Coupling(name = 'GC_8948',
                    value = '-((dgw*ee*complex(0,1)*complexconjugate(CKM3x1))/(sth*cmath.sqrt(2)))',
-                   order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll':1,'NPshifts':1,'QED':1})
+                   order = {'NP':1,'NPcHl3':1,'NPcll':1,'NPshifts':1,'QED':1})
 
 GC_8949 = Coupling(name = 'GC_8949',
                    value = '-((cdWIm31*ee*complexconjugate(CKM3x1))/(LambdaSMEFT**2*sth*cmath.sqrt(2)))',

--- a/UFO_models/SMEFTsim_general_MwScheme_UFO_v3_0/vertices.py
+++ b/UFO_models/SMEFTsim_general_MwScheme_UFO_v3_0/vertices.py
@@ -393,6 +393,12 @@ V_64 = Vertex(name = 'V_64',
               lorentz = [ L.VVS2, L.VVS3, L.VVS4 ],
               couplings = {(0,0):C.GC_6599,(0,2):C.GC_6598,(0,1):C.GC_7509})
 
+V_6400 = Vertex(name = 'V_6400',
+              particles = [ P.Z, P.Z, P.H ],
+              color = [ '1' ],
+              lorentz = [ L.VVS3 ],
+              couplings = {(0,0):C.GC_750900})
+
 V_65 = Vertex(name = 'V_65',
               particles = [ P.Z, P.Z, P.H ],
               color = [ '1' ],

--- a/UFO_models/SMEFTsim_topU3l_MwScheme_UFO_v3_0/couplings.py
+++ b/UFO_models/SMEFTsim_topU3l_MwScheme_UFO_v3_0/couplings.py
@@ -27,19 +27,19 @@ GC_4 = Coupling(name = 'GC_4',
 
 GC_5 = Coupling(name = 'GC_5',
                 value = '(cth**2*dg1*ee*complex(0,1))/3.',
-                order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_6 = Coupling(name = 'GC_6',
                 value = '(-2*cth**2*dg1*ee*complex(0,1))/3.',
-                order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_7 = Coupling(name = 'GC_7',
                 value = '-(cth**2*dg1*ee*complex(0,1))',
-                order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_8 = Coupling(name = 'GC_8',
                 value = 'cth**2*dg1*ee*complex(0,1)',
-                order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_9 = Coupling(name = 'GC_9',
                 value = 'ee**2*complex(0,1)',
@@ -47,15 +47,15 @@ GC_9 = Coupling(name = 'GC_9',
 
 GC_10 = Coupling(name = 'GC_10',
                  value = '(dg1*ee**2*complex(0,1))/cth**2',
-                 order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':2})
+                 order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':2})
 
 GC_11 = Coupling(name = 'GC_11',
                  value = '-2*cth**2*dg1*ee**2*complex(0,1)',
-                 order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':2})
+                 order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':2})
 
 GC_12 = Coupling(name = 'GC_12',
                  value = '2*cth**2*dg1*ee**2*complex(0,1)',
-                 order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':2})
+                 order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':2})
 
 GC_13 = Coupling(name = 'GC_13',
                  value = '-(complex(0,1)*G)',
@@ -759,11 +759,11 @@ GC_187 = Coupling(name = 'GC_187',
 
 GC_188 = Coupling(name = 'GC_188',
                   value = '(dgw*ee**2*complex(0,1))/sth**2',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':2})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':2})
 
 GC_189 = Coupling(name = 'GC_189',
                   value = '(-2*dgw*ee**2*complex(0,1))/sth**2',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':2})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':2})
 
 GC_190 = Coupling(name = 'GC_190',
                   value = '(dkH*ee**2*complex(0,1))/sth**2',
@@ -887,19 +887,19 @@ GC_219 = Coupling(name = 'GC_219',
 
 GC_220 = Coupling(name = 'GC_220',
                   value = '-((dgw*ee*complex(0,1))/(sth*cmath.sqrt(2)))',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_221 = Coupling(name = 'GC_221',
                   value = '-(dgw*ee*complex(0,1))/(2.*cth*sth)',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_222 = Coupling(name = 'GC_222',
                   value = '(dgw*ee*complex(0,1))/(2.*cth*sth)',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_223 = Coupling(name = 'GC_223',
                   value = '-(cth*dgw*ee*complex(0,1))/(2.*sth)',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_224 = Coupling(name = 'GC_224',
                   value = '(-2*cth*ee**2*complex(0,1))/sth',
@@ -1143,31 +1143,31 @@ GC_283 = Coupling(name = 'GC_283',
 
 GC_284 = Coupling(name = 'GC_284',
                   value = '-(dg1*ee*complex(0,1)*sth)/(6.*cth)',
-                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_285 = Coupling(name = 'GC_285',
                   value = '-(dg1*ee*complex(0,1)*sth)/(2.*cth)',
-                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_286 = Coupling(name = 'GC_286',
                   value = '(5*dg1*ee*complex(0,1)*sth)/(6.*cth)',
-                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_287 = Coupling(name = 'GC_287',
                   value = '(-3*dg1*ee*complex(0,1)*sth)/(2.*cth)',
-                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_288 = Coupling(name = 'GC_288',
                   value = 'cth*dg1*ee*complex(0,1)*sth',
-                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_289 = Coupling(name = 'GC_289',
                   value = '-(dgw*ee*complex(0,1)*sth)/(6.*cth)',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_290 = Coupling(name = 'GC_290',
                   value = '(dgw*ee*complex(0,1)*sth)/(2.*cth)',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_291 = Coupling(name = 'GC_291',
                   value = '(cbBIm*sth)/(LambdaSMEFT**2*cmath.sqrt(2))',
@@ -1279,23 +1279,23 @@ GC_317 = Coupling(name = 'GC_317',
 
 GC_318 = Coupling(name = 'GC_318',
                   value = '(dgw*ee*complex(0,1)*sth**2)/3.',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_319 = Coupling(name = 'GC_319',
                   value = '(-2*dgw*ee*complex(0,1)*sth**2)/3.',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_320 = Coupling(name = 'GC_320',
                   value = '-(dgw*ee*complex(0,1)*sth**2)',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_321 = Coupling(name = 'GC_321',
                   value = 'dgw*ee*complex(0,1)*sth**2',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_322 = Coupling(name = 'GC_322',
                   value = '2*dgw*ee**2*complex(0,1)*sth**2',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':2})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':2})
 
 GC_323 = Coupling(name = 'GC_323',
                   value = '(4*cHB*complex(0,1)*sth**2)/LambdaSMEFT**2',
@@ -1315,43 +1315,43 @@ GC_326 = Coupling(name = 'GC_326',
 
 GC_327 = Coupling(name = 'GC_327',
                   value = '(dg1*ee*complex(0,1)*sth**3)/(3.*cth)',
-                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_328 = Coupling(name = 'GC_328',
                   value = '(-2*dg1*ee*complex(0,1)*sth**3)/(3.*cth)',
-                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_329 = Coupling(name = 'GC_329',
                   value = '(dg1*ee*complex(0,1)*sth**3)/cth',
-                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_330 = Coupling(name = 'GC_330',
                   value = '-(dgw*ee*complex(0,1)*sth**3)/(3.*cth)',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_331 = Coupling(name = 'GC_331',
                   value = '(2*dgw*ee*complex(0,1)*sth**3)/(3.*cth)',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_332 = Coupling(name = 'GC_332',
                   value = '-((dgw*ee*complex(0,1)*sth**3)/cth)',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_333 = Coupling(name = 'GC_333',
                   value = '-((cth*dgw*ee*complex(0,1))/sth) - cth*dgw*ee*complex(0,1)*sth',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_334 = Coupling(name = 'GC_334',
                   value = '(-2*cth*dg1*ee**2*complex(0,1))/sth + 4*cth*dg1*ee**2*complex(0,1)*sth',
-                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':2})
+                  order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':2})
 
 GC_335 = Coupling(name = 'GC_335',
                   value = '(-2*cth*dgw*ee**2*complex(0,1))/sth - 4*cth*dgw*ee**2*complex(0,1)*sth',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':2})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':2})
 
 GC_336 = Coupling(name = 'GC_336',
                   value = '(2*dgw*ee**2*complex(0,1))/sth**2 - 2*dgw*ee**2*complex(0,1)*sth**2',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':2})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':2})
 
 GC_337 = Coupling(name = 'GC_337',
                   value = '(-2*cHWB*complex(0,1))/LambdaSMEFT**2 + (4*cHWB*complex(0,1)*sth**2)/LambdaSMEFT**2',
@@ -1755,7 +1755,7 @@ GC_436 = Coupling(name = 'GC_436',
 
 GC_437 = Coupling(name = 'GC_437',
                   value = '(dgw*ee**2*complex(0,1)*vevhat)/sth**2',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_438 = Coupling(name = 'GC_438',
                   value = '(dkH*ee**2*complex(0,1)*vevhat)/(2.*sth**2)',
@@ -2214,7 +2214,11 @@ GC_551 = Coupling(name = 'GC_551',
                   order = {'NP':1,'NPcHWB':1,'QED':1})
 
 GC_552 = Coupling(name = 'GC_552',
-                  value = '(dg1*ee**2*complex(0,1)*vevhat)/cth**2 + (dGf*ee**2*complex(0,1)*vevhat)/(4.*cth**2*sth**2)',
+                  value = '(dg1*ee**2*complex(0,1)*vevhat)/cth**2',
+                  order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+
+GC_55200 = Coupling(name = 'GC_55200',
+                  value = '(dGf*ee**2*complex(0,1)*vevhat)/(4.*cth**2*sth**2)',
                   order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_553 = Coupling(name = 'GC_553',

--- a/UFO_models/SMEFTsim_topU3l_MwScheme_UFO_v3_0/vertices.py
+++ b/UFO_models/SMEFTsim_topU3l_MwScheme_UFO_v3_0/vertices.py
@@ -393,6 +393,12 @@ V_64 = Vertex(name = 'V_64',
               lorentz = [ L.VVS2, L.VVS3, L.VVS4 ],
               couplings = {(0,0):C.GC_405,(0,2):C.GC_404,(0,1):C.GC_552})
 
+V_6400 = Vertex(name = 'V_6400',
+              particles = [ P.Z, P.Z, P.H ],
+              color = [ '1' ],
+              lorentz = [ L.VVS3 ],
+              couplings = {(0,0):C.GC_55200})
+
 V_65 = Vertex(name = 'V_65',
               particles = [ P.Z, P.Z, P.H ],
               color = [ '1' ],

--- a/UFO_models/SMEFTsim_top_MwScheme_UFO_v3_0/couplings.py
+++ b/UFO_models/SMEFTsim_top_MwScheme_UFO_v3_0/couplings.py
@@ -27,19 +27,19 @@ GC_4 = Coupling(name = 'GC_4',
 
 GC_5 = Coupling(name = 'GC_5',
                 value = '(cth**2*dg1*ee*complex(0,1))/3.',
-                order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_6 = Coupling(name = 'GC_6',
                 value = '(-2*cth**2*dg1*ee*complex(0,1))/3.',
-                order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_7 = Coupling(name = 'GC_7',
                 value = '-(cth**2*dg1*ee*complex(0,1))',
-                order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_8 = Coupling(name = 'GC_8',
                 value = 'cth**2*dg1*ee*complex(0,1)',
-                order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_9 = Coupling(name = 'GC_9',
                 value = 'ee**2*complex(0,1)',
@@ -47,15 +47,15 @@ GC_9 = Coupling(name = 'GC_9',
 
 GC_10 = Coupling(name = 'GC_10',
                  value = '(dg1*ee**2*complex(0,1))/cth**2',
-                 order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':2})
+                 order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':2})
 
 GC_11 = Coupling(name = 'GC_11',
                  value = '-2*cth**2*dg1*ee**2*complex(0,1)',
-                 order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':2})
+                 order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':2})
 
 GC_12 = Coupling(name = 'GC_12',
                  value = '2*cth**2*dg1*ee**2*complex(0,1)',
-                 order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':2})
+                 order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':2})
 
 GC_13 = Coupling(name = 'GC_13',
                  value = '-(complex(0,1)*G)',
@@ -1319,11 +1319,11 @@ GC_327 = Coupling(name = 'GC_327',
 
 GC_328 = Coupling(name = 'GC_328',
                   value = '(dgw*ee**2*complex(0,1))/sth**2',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':2})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':2})
 
 GC_329 = Coupling(name = 'GC_329',
                   value = '(-2*dgw*ee**2*complex(0,1))/sth**2',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':2})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':2})
 
 GC_330 = Coupling(name = 'GC_330',
                   value = '(dkH*ee**2*complex(0,1))/sth**2',
@@ -1447,19 +1447,19 @@ GC_359 = Coupling(name = 'GC_359',
 
 GC_360 = Coupling(name = 'GC_360',
                   value = '-((dgw*ee*complex(0,1))/(sth*cmath.sqrt(2)))',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_361 = Coupling(name = 'GC_361',
                   value = '-(dgw*ee*complex(0,1))/(2.*cth*sth)',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_362 = Coupling(name = 'GC_362',
                   value = '(dgw*ee*complex(0,1))/(2.*cth*sth)',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_363 = Coupling(name = 'GC_363',
                   value = '-(cth*dgw*ee*complex(0,1))/(2.*sth)',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_364 = Coupling(name = 'GC_364',
                   value = '(-2*cth*ee**2*complex(0,1))/sth',
@@ -1803,31 +1803,31 @@ GC_448 = Coupling(name = 'GC_448',
 
 GC_449 = Coupling(name = 'GC_449',
                   value = '-(dg1*ee*complex(0,1)*sth)/(6.*cth)',
-                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_450 = Coupling(name = 'GC_450',
                   value = '-(dg1*ee*complex(0,1)*sth)/(2.*cth)',
-                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_451 = Coupling(name = 'GC_451',
                   value = '(5*dg1*ee*complex(0,1)*sth)/(6.*cth)',
-                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_452 = Coupling(name = 'GC_452',
                   value = '(-3*dg1*ee*complex(0,1)*sth)/(2.*cth)',
-                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_453 = Coupling(name = 'GC_453',
                   value = 'cth*dg1*ee*complex(0,1)*sth',
-                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_454 = Coupling(name = 'GC_454',
                   value = '-(dgw*ee*complex(0,1)*sth)/(6.*cth)',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_455 = Coupling(name = 'GC_455',
                   value = '(dgw*ee*complex(0,1)*sth)/(2.*cth)',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_456 = Coupling(name = 'GC_456',
                   value = '(cbBIm*sth)/(LambdaSMEFT**2*cmath.sqrt(2))',
@@ -1987,23 +1987,23 @@ GC_494 = Coupling(name = 'GC_494',
 
 GC_495 = Coupling(name = 'GC_495',
                   value = '(dgw*ee*complex(0,1)*sth**2)/3.',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_496 = Coupling(name = 'GC_496',
                   value = '(-2*dgw*ee*complex(0,1)*sth**2)/3.',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_497 = Coupling(name = 'GC_497',
                   value = '-(dgw*ee*complex(0,1)*sth**2)',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_498 = Coupling(name = 'GC_498',
                   value = 'dgw*ee*complex(0,1)*sth**2',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_499 = Coupling(name = 'GC_499',
                   value = '2*dgw*ee**2*complex(0,1)*sth**2',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':2})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':2})
 
 GC_500 = Coupling(name = 'GC_500',
                   value = '(4*cHB*complex(0,1)*sth**2)/LambdaSMEFT**2',
@@ -2023,43 +2023,43 @@ GC_503 = Coupling(name = 'GC_503',
 
 GC_504 = Coupling(name = 'GC_504',
                   value = '(dg1*ee*complex(0,1)*sth**3)/(3.*cth)',
-                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_505 = Coupling(name = 'GC_505',
                   value = '(-2*dg1*ee*complex(0,1)*sth**3)/(3.*cth)',
-                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_506 = Coupling(name = 'GC_506',
                   value = '(dg1*ee*complex(0,1)*sth**3)/cth',
-                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_507 = Coupling(name = 'GC_507',
                   value = '-(dgw*ee*complex(0,1)*sth**3)/(3.*cth)',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_508 = Coupling(name = 'GC_508',
                   value = '(2*dgw*ee*complex(0,1)*sth**3)/(3.*cth)',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_509 = Coupling(name = 'GC_509',
                   value = '-((dgw*ee*complex(0,1)*sth**3)/cth)',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_510 = Coupling(name = 'GC_510',
                   value = '-((cth*dgw*ee*complex(0,1))/sth) - cth*dgw*ee*complex(0,1)*sth',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_511 = Coupling(name = 'GC_511',
                   value = '(-2*cth*dg1*ee**2*complex(0,1))/sth + 4*cth*dg1*ee**2*complex(0,1)*sth',
-                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':2})
+                  order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':2})
 
 GC_512 = Coupling(name = 'GC_512',
                   value = '(-2*cth*dgw*ee**2*complex(0,1))/sth - 4*cth*dgw*ee**2*complex(0,1)*sth',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':2})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':2})
 
 GC_513 = Coupling(name = 'GC_513',
                   value = '(2*dgw*ee**2*complex(0,1))/sth**2 - 2*dgw*ee**2*complex(0,1)*sth**2',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':2})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':2})
 
 GC_514 = Coupling(name = 'GC_514',
                   value = '(-2*cHWB*complex(0,1))/LambdaSMEFT**2 + (4*cHWB*complex(0,1)*sth**2)/LambdaSMEFT**2',
@@ -2607,7 +2607,7 @@ GC_649 = Coupling(name = 'GC_649',
 
 GC_650 = Coupling(name = 'GC_650',
                   value = '(dgw*ee**2*complex(0,1)*vevhat)/sth**2',
-                  order = {'NP':1,'NPcHDD':1,'NPcHl3':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_651 = Coupling(name = 'GC_651',
                   value = '(dkH*ee**2*complex(0,1)*vevhat)/(2.*sth**2)',
@@ -3278,7 +3278,11 @@ GC_817 = Coupling(name = 'GC_817',
                   order = {'NP':1,'NPcHWB':1,'QED':1})
 
 GC_818 = Coupling(name = 'GC_818',
-                  value = '(dg1*ee**2*complex(0,1)*vevhat)/cth**2 + (dGf*ee**2*complex(0,1)*vevhat)/(4.*cth**2*sth**2)',
+                  value = '(dg1*ee**2*complex(0,1)*vevhat)/cth**2',
+                  order = {'NP':1,'NPcHl3':1,'NPcHDD':1,'NPcHWB':1,'NPcll1':1,'NPshifts':1,'QED':1})
+
+GC_81800 = Coupling(name = 'GC_81800',
+                  value = '(dGf*ee**2*complex(0,1)*vevhat)/(4.*cth**2*sth**2)',
                   order = {'NP':1,'NPcHl3':1,'NPcll1':1,'NPshifts':1,'QED':1})
 
 GC_819 = Coupling(name = 'GC_819',

--- a/UFO_models/SMEFTsim_top_MwScheme_UFO_v3_0/vertices.py
+++ b/UFO_models/SMEFTsim_top_MwScheme_UFO_v3_0/vertices.py
@@ -393,6 +393,12 @@ V_64 = Vertex(name = 'V_64',
               lorentz = [ L.VVS2, L.VVS3, L.VVS4 ],
               couplings = {(0,0):C.GC_609,(0,2):C.GC_608,(0,1):C.GC_818})
 
+V_6400 = Vertex(name = 'V_6400',
+              particles = [ P.Z, P.Z, P.H ],
+              color = [ '1' ],
+              lorentz = [ L.VVS3 ],
+              couplings = {(0,0):C.GC_81800})
+
 V_65 = Vertex(name = 'V_65',
               particles = [ P.Z, P.Z, P.H ],
               color = [ '1' ],


### PR DESCRIPTION
The Wilson coefficient-specific interaction orders of `dg1` and `dgw` were erroneously swapped in m_W-scheme models. 
The issue affected orders `NPcHDD`, `NPcHWB`.
The correct orders are now assigned.

Reported by @GiacomoBoldrini @govoni