### PR TITLE
feat: Migrate UFO_models to Python 3.6+

### DIFF
--- a/UFO_models/SMEFTsim_MFV_MwScheme_UFO/CT_couplings.py
+++ b/UFO_models/SMEFTsim_MFV_MwScheme_UFO/CT_couplings.py
@@ -3,9 +3,9 @@
 # Date: Sat 1 Aug 2020 04:48:11
 
 
-from object_library import all_couplings, Coupling
+from .object_library import all_couplings, Coupling
 
-from function_library import complexconjugate, re, im, csc, sec, acsc, asec, cot
+from .function_library import complexconjugate, re, im, csc, sec, acsc, asec, cot
 
 
 

--- a/UFO_models/SMEFTsim_MFV_MwScheme_UFO/__init__.py
+++ b/UFO_models/SMEFTsim_MFV_MwScheme_UFO/__init__.py
@@ -1,14 +1,13 @@
+from . import particles
+from . import couplings
+from . import lorentz
+from . import parameters
+from . import vertices
+from . import coupling_orders
+from . import write_param_card
+from . import propagators
 
-import particles
-import couplings
-import lorentz
-import parameters
-import vertices
-import coupling_orders
-import write_param_card
-import propagators
-
-import function_library
+from . import function_library
 
 
 all_particles = particles.all_particles
@@ -21,7 +20,7 @@ all_functions = function_library.all_functions
 all_propagators = propagators.all_propagators
 
 try:
-   import decays
+   from . import decays
 except ImportError:
    pass
 else:

--- a/UFO_models/SMEFTsim_MFV_MwScheme_UFO/coupling_orders.py
+++ b/UFO_models/SMEFTsim_MFV_MwScheme_UFO/coupling_orders.py
@@ -3,7 +3,7 @@
 # Date: Sat 1 Aug 2020 04:48:03
 
 
-from object_library import all_orders, CouplingOrder
+from .object_library import all_orders, CouplingOrder
 
 
 QCD = CouplingOrder(name = 'QCD',

--- a/UFO_models/SMEFTsim_MFV_MwScheme_UFO/couplings.py
+++ b/UFO_models/SMEFTsim_MFV_MwScheme_UFO/couplings.py
@@ -3,9 +3,9 @@
 # Date: Thu 7 Jan 2021 11:40:43
 
 
-from object_library import all_couplings, Coupling
+from .object_library import all_couplings, Coupling
 
-from function_library import complexconjugate, re, im, csc, sec, acsc, asec, cot
+from .function_library import complexconjugate, re, im, csc, sec, acsc, asec, cot
 
 
 

--- a/UFO_models/SMEFTsim_MFV_MwScheme_UFO/decays.py
+++ b/UFO_models/SMEFTsim_MFV_MwScheme_UFO/decays.py
@@ -3,8 +3,8 @@
 # Date: Thu 7 Jan 2021 11:40:48
 
 
-from object_library import all_decays, Decay
-import particles as P
+from .object_library import all_decays, Decay
+from . import particles as P
 
 
 Decay_b = Decay(name = 'Decay_b',

--- a/UFO_models/SMEFTsim_MFV_MwScheme_UFO/function_library.py
+++ b/UFO_models/SMEFTsim_MFV_MwScheme_UFO/function_library.py
@@ -12,7 +12,7 @@ __date__ = "22 July 2010"
 __author__ = "claude.duhr@durham.ac.uk"
 
 import cmath
-from object_library import all_functions, Function
+from .object_library import all_functions, Function
 
 #
 # shortcuts for functions from cmath

--- a/UFO_models/SMEFTsim_MFV_MwScheme_UFO/lorentz.py
+++ b/UFO_models/SMEFTsim_MFV_MwScheme_UFO/lorentz.py
@@ -3,9 +3,9 @@
 # Date: Thu 7 Jan 2021 11:40:43
 
 
-from object_library import all_lorentz, Lorentz
+from .object_library import all_lorentz, Lorentz
 
-from function_library import complexconjugate, re, im, csc, sec, acsc, asec, cot
+from .function_library import complexconjugate, re, im, csc, sec, acsc, asec, cot
 try:
    import form_factors as ForFac 
 except ImportError:

--- a/UFO_models/SMEFTsim_MFV_MwScheme_UFO/object_library.py
+++ b/UFO_models/SMEFTsim_MFV_MwScheme_UFO/object_library.py
@@ -14,7 +14,7 @@ class UFOError(Exception):
         """Exception raised if when inconsistencies are detected in the UFO model."""
         pass
 
-class UFOBaseClass(object):
+class UFOBaseClass:
     """The class from which all FeynRules classes are derived."""
 
     require_args = []
@@ -133,7 +133,7 @@ class Particle(UFOBaseClass):
         if self.selfconjugate:
             raise Exception('%s has no anti particle.' % self.name) 
         outdic = {}
-        for k,v in self.__dict__.iteritems():
+        for k,v in self.__dict__.items():
             if k not in self.require_args_all:                
                 outdic[k] = -v
         if self.color in [1,8]:
@@ -265,9 +265,9 @@ class Coupling(UFOBaseClass):
                if not CTparam:
                    CTparam=param
                else:
-                   raise UFOError, "UFO does not support yet more than one occurence of CTParameters in the couplings values."
+                   raise UFOError("UFO does not support yet more than one occurence of CTParameters in the couplings values.")
            elif numberOfMatches>1:
-               raise UFOError, "UFO does not support yet more than one occurence of CTParameters in the couplings values."
+               raise UFOError("UFO does not support yet more than one occurence of CTParameters in the couplings values.")
 
         if not CTparam:
             if x==0:
@@ -299,7 +299,7 @@ class Lorentz(UFOBaseClass):
 
 all_functions = []
 
-class Function(object):
+class Function:
 
     def __init__(self, name, arguments, expression):
 
@@ -313,13 +313,13 @@ class Function(object):
     def __call__(self, *opt):
 
         for i, arg in enumerate(self.arguments):
-            exec('%s = %s' % (arg, opt[i] ))
+            exec(f'{arg} = {opt[i]}')
 
         return eval(self.expr)
 
 all_orders = []
 
-class CouplingOrder(object):
+class CouplingOrder:
 
     def __init__(self, name, expansion_order, hierarchy, perturbative_expansion = 0):
         

--- a/UFO_models/SMEFTsim_MFV_MwScheme_UFO/parameters.py
+++ b/UFO_models/SMEFTsim_MFV_MwScheme_UFO/parameters.py
@@ -4,10 +4,10 @@
 
 
 
-from object_library import all_parameters, Parameter
+from .object_library import all_parameters, Parameter
 
 
-from function_library import complexconjugate, re, im, csc, sec, acsc, asec, cot
+from .function_library import complexconjugate, re, im, csc, sec, acsc, asec, cot
 
 # This is a default parameter object representing 0.
 ZERO = Parameter(name = 'ZERO',

--- a/UFO_models/SMEFTsim_MFV_MwScheme_UFO/particles.py
+++ b/UFO_models/SMEFTsim_MFV_MwScheme_UFO/particles.py
@@ -3,11 +3,11 @@
 # Date: Tue 7 Apr 2020 10:47:23
 
 
-from __future__ import division
-from object_library import all_particles, Particle
-import parameters as Param
 
-import propagators as Prop
+from .object_library import all_particles, Particle
+from . import parameters as Param
+
+from . import propagators as Prop
 
 a = Particle(pdg_code = 22,
              name = 'a',

--- a/UFO_models/SMEFTsim_MFV_MwScheme_UFO/propagators.py
+++ b/UFO_models/SMEFTsim_MFV_MwScheme_UFO/propagators.py
@@ -2,7 +2,7 @@
 # Mathematica version: 8.0 for Mac OS X x86 (64-bit) (November 6, 2010)
 # Date: Mon 1 Oct 2012 14:58:26
 
-from object_library import all_propagators, Propagator
+from .object_library import all_propagators, Propagator
 
 
 # define only once the denominator since this is always the same

--- a/UFO_models/SMEFTsim_MFV_MwScheme_UFO/vertices.py
+++ b/UFO_models/SMEFTsim_MFV_MwScheme_UFO/vertices.py
@@ -3,10 +3,10 @@
 # Date: Thu 7 Jan 2021 11:40:42
 
 
-from object_library import all_vertices, Vertex
-import particles as P
-import couplings as C
-import lorentz as L
+from .object_library import all_vertices, Vertex
+from . import particles as P
+from . import couplings as C
+from . import lorentz as L
 
 
 V_1 = Vertex(name = 'V_1',

--- a/UFO_models/SMEFTsim_MFV_MwScheme_UFO/write_param_card.py
+++ b/UFO_models/SMEFTsim_MFV_MwScheme_UFO/write_param_card.py
@@ -1,10 +1,9 @@
-
 __date__ = "02 Aug 2012"
 __author__ = 'olivier.mattelaer@uclouvain.be'
 
-from function_library import *
+from .function_library import *
 
-class ParamCardWriter(object):
+class ParamCardWriter:
     
     header = \
     """######################################################################\n""" + \
@@ -15,7 +14,7 @@ class ParamCardWriter(object):
         """write a valid param_card.dat"""
         
         if not list_of_parameters:
-            from parameters import all_parameters
+            from .parameters import all_parameters
             list_of_parameters = [param for param in all_parameters if \
                                                        param.nature=='external']
         
@@ -33,7 +32,7 @@ class ParamCardWriter(object):
     def define_not_dep_param(self, list_of_parameters):
         """define self.dep_mass and self.dep_width in case that they are 
         requested in the param_card.dat"""
-        from particles import all_particles
+        from .particles import all_particles
         
         self.dep_mass = [(part, part.mass) for part in all_particles \
                             if part.pdg_code > 0 and \
@@ -67,7 +66,7 @@ class ParamCardWriter(object):
         """ """
         
         # list all lhablock
-        all_lhablock = set([param.lhablock for param in all_ext_param])
+        all_lhablock = {param.lhablock for param in all_ext_param}
         
         # ordonate lhablock alphabeticaly
         all_lhablock = list(all_lhablock)
@@ -108,9 +107,9 @@ class ParamCardWriter(object):
         
         lhacode=' '.join(['%3s' % key for key in param.lhacode])
         if lhablock != 'DECAY':
-            text = """  %s %e # %s \n""" % (lhacode, complex(param.value).real, param.name ) 
+            text = f"""  {lhacode} {complex(param.value).real:e} # {param.name} \n""" 
         else:
-            text = '''DECAY %s %e \n''' % (lhacode, complex(param.value).real)
+            text = f'''DECAY {lhacode} {complex(param.value).real:e} \n'''
         self.fsock.write(text) 
                     
 
@@ -118,10 +117,10 @@ class ParamCardWriter(object):
     
     def write_dep_param_block(self, lhablock):
         import cmath
-        from parameters import all_parameters
-        from particles import all_particles
+        from .parameters import all_parameters
+        from .particles import all_particles
         for parameter in all_parameters:
-            exec("%s = %s" % (parameter.name, parameter.value))
+            exec(f"{parameter.name} = {parameter.value}")
         text = "##  Not dependent paramater.\n"
         text += "## Those values should be edited following analytical the \n"
         text += "## analytical expression. Some generator could simply ignore \n"
@@ -177,9 +176,9 @@ class ParamCardWriter(object):
     
     def write_qnumber(self):
         """ write qnumber """
-        from particles import all_particles
-        import particles
-        print particles.__file__
+        from .particles import all_particles
+        from . import particles
+        print(particles.__file__)
         text="""#===========================================================\n"""
         text += """# QUANTUM NUMBERS OF NEW STATE(S) (NON SM PDG CODE)\n"""
         text += """#===========================================================\n\n"""
@@ -204,5 +203,5 @@ class ParamCardWriter(object):
             
 if '__main__' == __name__:
     ParamCardWriter('./param_card.dat', generic=True)
-    print 'write ./param_card.dat'
+    print('write ./param_card.dat')
     

--- a/UFO_models/SMEFTsim_MFV_alphaScheme_UFO/CT_couplings.py
+++ b/UFO_models/SMEFTsim_MFV_alphaScheme_UFO/CT_couplings.py
@@ -3,9 +3,9 @@
 # Date: Fri 31 Jul 2020 07:55:17
 
 
-from object_library import all_couplings, Coupling
+from .object_library import all_couplings, Coupling
 
-from function_library import complexconjugate, re, im, csc, sec, acsc, asec, cot
+from .function_library import complexconjugate, re, im, csc, sec, acsc, asec, cot
 
 
 

--- a/UFO_models/SMEFTsim_MFV_alphaScheme_UFO/__init__.py
+++ b/UFO_models/SMEFTsim_MFV_alphaScheme_UFO/__init__.py
@@ -1,14 +1,13 @@
+from . import particles
+from . import couplings
+from . import lorentz
+from . import parameters
+from . import vertices
+from . import coupling_orders
+from . import write_param_card
+from . import propagators
 
-import particles
-import couplings
-import lorentz
-import parameters
-import vertices
-import coupling_orders
-import write_param_card
-import propagators
-
-import function_library
+from . import function_library
 
 
 all_particles = particles.all_particles
@@ -21,7 +20,7 @@ all_functions = function_library.all_functions
 all_propagators = propagators.all_propagators
 
 try:
-   import decays
+   from . import decays
 except ImportError:
    pass
 else:

--- a/UFO_models/SMEFTsim_MFV_alphaScheme_UFO/coupling_orders.py
+++ b/UFO_models/SMEFTsim_MFV_alphaScheme_UFO/coupling_orders.py
@@ -3,7 +3,7 @@
 # Date: Fri 31 Jul 2020 07:55:10
 
 
-from object_library import all_orders, CouplingOrder
+from .object_library import all_orders, CouplingOrder
 
 
 QCD = CouplingOrder(name = 'QCD',

--- a/UFO_models/SMEFTsim_MFV_alphaScheme_UFO/couplings.py
+++ b/UFO_models/SMEFTsim_MFV_alphaScheme_UFO/couplings.py
@@ -3,9 +3,9 @@
 # Date: Mon 11 Jan 2021 01:44:34
 
 
-from object_library import all_couplings, Coupling
+from .object_library import all_couplings, Coupling
 
-from function_library import complexconjugate, re, im, csc, sec, acsc, asec, cot
+from .function_library import complexconjugate, re, im, csc, sec, acsc, asec, cot
 
 
 

--- a/UFO_models/SMEFTsim_MFV_alphaScheme_UFO/function_library.py
+++ b/UFO_models/SMEFTsim_MFV_alphaScheme_UFO/function_library.py
@@ -12,7 +12,7 @@ __date__ = "22 July 2010"
 __author__ = "claude.duhr@durham.ac.uk"
 
 import cmath
-from object_library import all_functions, Function
+from .object_library import all_functions, Function
 
 #
 # shortcuts for functions from cmath

--- a/UFO_models/SMEFTsim_MFV_alphaScheme_UFO/lorentz.py
+++ b/UFO_models/SMEFTsim_MFV_alphaScheme_UFO/lorentz.py
@@ -3,9 +3,9 @@
 # Date: Mon 11 Jan 2021 01:44:34
 
 
-from object_library import all_lorentz, Lorentz
+from .object_library import all_lorentz, Lorentz
 
-from function_library import complexconjugate, re, im, csc, sec, acsc, asec, cot
+from .function_library import complexconjugate, re, im, csc, sec, acsc, asec, cot
 try:
    import form_factors as ForFac 
 except ImportError:

--- a/UFO_models/SMEFTsim_MFV_alphaScheme_UFO/object_library.py
+++ b/UFO_models/SMEFTsim_MFV_alphaScheme_UFO/object_library.py
@@ -14,7 +14,7 @@ class UFOError(Exception):
         """Exception raised if when inconsistencies are detected in the UFO model."""
         pass
 
-class UFOBaseClass(object):
+class UFOBaseClass:
     """The class from which all FeynRules classes are derived."""
 
     require_args = []
@@ -133,7 +133,7 @@ class Particle(UFOBaseClass):
         if self.selfconjugate:
             raise Exception('%s has no anti particle.' % self.name) 
         outdic = {}
-        for k,v in self.__dict__.iteritems():
+        for k,v in self.__dict__.items():
             if k not in self.require_args_all:                
                 outdic[k] = -v
         if self.color in [1,8]:
@@ -265,9 +265,9 @@ class Coupling(UFOBaseClass):
                if not CTparam:
                    CTparam=param
                else:
-                   raise UFOError, "UFO does not support yet more than one occurence of CTParameters in the couplings values."
+                   raise UFOError("UFO does not support yet more than one occurence of CTParameters in the couplings values.")
            elif numberOfMatches>1:
-               raise UFOError, "UFO does not support yet more than one occurence of CTParameters in the couplings values."
+               raise UFOError("UFO does not support yet more than one occurence of CTParameters in the couplings values.")
 
         if not CTparam:
             if x==0:
@@ -299,7 +299,7 @@ class Lorentz(UFOBaseClass):
 
 all_functions = []
 
-class Function(object):
+class Function:
 
     def __init__(self, name, arguments, expression):
 
@@ -313,13 +313,13 @@ class Function(object):
     def __call__(self, *opt):
 
         for i, arg in enumerate(self.arguments):
-            exec('%s = %s' % (arg, opt[i] ))
+            exec(f'{arg} = {opt[i]}')
 
         return eval(self.expr)
 
 all_orders = []
 
-class CouplingOrder(object):
+class CouplingOrder:
 
     def __init__(self, name, expansion_order, hierarchy, perturbative_expansion = 0):
         

--- a/UFO_models/SMEFTsim_MFV_alphaScheme_UFO/parameters.py
+++ b/UFO_models/SMEFTsim_MFV_alphaScheme_UFO/parameters.py
@@ -4,10 +4,10 @@
 
 
 
-from object_library import all_parameters, Parameter
+from .object_library import all_parameters, Parameter
 
 
-from function_library import complexconjugate, re, im, csc, sec, acsc, asec
+from .function_library import complexconjugate, re, im, csc, sec, acsc, asec
 
 # This is a default parameter object representing 0.
 ZERO = Parameter(name = 'ZERO',

--- a/UFO_models/SMEFTsim_MFV_alphaScheme_UFO/particles.py
+++ b/UFO_models/SMEFTsim_MFV_alphaScheme_UFO/particles.py
@@ -3,11 +3,11 @@
 # Date: Tue 7 Apr 2020 10:47:23
 
 
-from __future__ import division
-from object_library import all_particles, Particle
-import parameters as Param
 
-import propagators as Prop
+from .object_library import all_particles, Particle
+from . import parameters as Param
+
+from . import propagators as Prop
 
 a = Particle(pdg_code = 22,
              name = 'a',

--- a/UFO_models/SMEFTsim_MFV_alphaScheme_UFO/propagators.py
+++ b/UFO_models/SMEFTsim_MFV_alphaScheme_UFO/propagators.py
@@ -2,7 +2,7 @@
 # Mathematica version: 8.0 for Mac OS X x86 (64-bit) (November 6, 2010)
 # Date: Mon 1 Oct 2012 14:58:26
 
-from object_library import all_propagators, Propagator
+from .object_library import all_propagators, Propagator
 
 
 # define only once the denominator since this is always the same

--- a/UFO_models/SMEFTsim_MFV_alphaScheme_UFO/vertices.py
+++ b/UFO_models/SMEFTsim_MFV_alphaScheme_UFO/vertices.py
@@ -3,10 +3,10 @@
 # Date: Mon 11 Jan 2021 01:44:33
 
 
-from object_library import all_vertices, Vertex
-import particles as P
-import couplings as C
-import lorentz as L
+from .object_library import all_vertices, Vertex
+from . import particles as P
+from . import couplings as C
+from . import lorentz as L
 
 
 V_1 = Vertex(name = 'V_1',

--- a/UFO_models/SMEFTsim_MFV_alphaScheme_UFO/write_param_card.py
+++ b/UFO_models/SMEFTsim_MFV_alphaScheme_UFO/write_param_card.py
@@ -1,10 +1,9 @@
-
 __date__ = "02 Aug 2012"
 __author__ = 'olivier.mattelaer@uclouvain.be'
 
-from function_library import *
+from .function_library import *
 
-class ParamCardWriter(object):
+class ParamCardWriter:
     
     header = \
     """######################################################################\n""" + \
@@ -15,7 +14,7 @@ class ParamCardWriter(object):
         """write a valid param_card.dat"""
         
         if not list_of_parameters:
-            from parameters import all_parameters
+            from .parameters import all_parameters
             list_of_parameters = [param for param in all_parameters if \
                                                        param.nature=='external']
         
@@ -33,7 +32,7 @@ class ParamCardWriter(object):
     def define_not_dep_param(self, list_of_parameters):
         """define self.dep_mass and self.dep_width in case that they are 
         requested in the param_card.dat"""
-        from particles import all_particles
+        from .particles import all_particles
         
         self.dep_mass = [(part, part.mass) for part in all_particles \
                             if part.pdg_code > 0 and \
@@ -67,7 +66,7 @@ class ParamCardWriter(object):
         """ """
         
         # list all lhablock
-        all_lhablock = set([param.lhablock for param in all_ext_param])
+        all_lhablock = {param.lhablock for param in all_ext_param}
         
         # ordonate lhablock alphabeticaly
         all_lhablock = list(all_lhablock)
@@ -108,9 +107,9 @@ class ParamCardWriter(object):
         
         lhacode=' '.join(['%3s' % key for key in param.lhacode])
         if lhablock != 'DECAY':
-            text = """  %s %e # %s \n""" % (lhacode, complex(param.value).real, param.name ) 
+            text = f"""  {lhacode} {complex(param.value).real:e} # {param.name} \n""" 
         else:
-            text = '''DECAY %s %e \n''' % (lhacode, complex(param.value).real)
+            text = f'''DECAY {lhacode} {complex(param.value).real:e} \n'''
         self.fsock.write(text) 
                     
 
@@ -118,10 +117,10 @@ class ParamCardWriter(object):
     
     def write_dep_param_block(self, lhablock):
         import cmath
-        from parameters import all_parameters
-        from particles import all_particles
+        from .parameters import all_parameters
+        from .particles import all_particles
         for parameter in all_parameters:
-            exec("%s = %s" % (parameter.name, parameter.value))
+            exec(f"{parameter.name} = {parameter.value}")
         text = "##  Not dependent paramater.\n"
         text += "## Those values should be edited following analytical the \n"
         text += "## analytical expression. Some generator could simply ignore \n"
@@ -177,9 +176,9 @@ class ParamCardWriter(object):
     
     def write_qnumber(self):
         """ write qnumber """
-        from particles import all_particles
-        import particles
-        print particles.__file__
+        from .particles import all_particles
+        from . import particles
+        print(particles.__file__)
         text="""#===========================================================\n"""
         text += """# QUANTUM NUMBERS OF NEW STATE(S) (NON SM PDG CODE)\n"""
         text += """#===========================================================\n\n"""
@@ -204,5 +203,5 @@ class ParamCardWriter(object):
             
 if '__main__' == __name__:
     ParamCardWriter('./param_card.dat', generic=True)
-    print 'write ./param_card.dat'
+    print('write ./param_card.dat')
     

--- a/UFO_models/SMEFTsim_U35_MwScheme_UFO/CT_couplings.py
+++ b/UFO_models/SMEFTsim_U35_MwScheme_UFO/CT_couplings.py
@@ -3,9 +3,9 @@
 # Date: Tue 18 Aug 2020 11:20:03
 
 
-from object_library import all_couplings, Coupling
+from .object_library import all_couplings, Coupling
 
-from function_library import complexconjugate, re, im, csc, sec, acsc, asec, cot
+from .function_library import complexconjugate, re, im, csc, sec, acsc, asec, cot
 
 
 

--- a/UFO_models/SMEFTsim_U35_MwScheme_UFO/__init__.py
+++ b/UFO_models/SMEFTsim_U35_MwScheme_UFO/__init__.py
@@ -1,14 +1,13 @@
+from . import particles
+from . import couplings
+from . import lorentz
+from . import parameters
+from . import vertices
+from . import coupling_orders
+from . import write_param_card
+from . import propagators
 
-import particles
-import couplings
-import lorentz
-import parameters
-import vertices
-import coupling_orders
-import write_param_card
-import propagators
-
-import function_library
+from . import function_library
 
 
 all_particles = particles.all_particles
@@ -21,7 +20,7 @@ all_functions = function_library.all_functions
 all_propagators = propagators.all_propagators
 
 try:
-   import decays
+   from . import decays
 except ImportError:
    pass
 else:

--- a/UFO_models/SMEFTsim_U35_MwScheme_UFO/coupling_orders.py
+++ b/UFO_models/SMEFTsim_U35_MwScheme_UFO/coupling_orders.py
@@ -3,7 +3,7 @@
 # Date: Tue 18 Aug 2020 11:20:03
 
 
-from object_library import all_orders, CouplingOrder
+from .object_library import all_orders, CouplingOrder
 
 
 QCD = CouplingOrder(name = 'QCD',

--- a/UFO_models/SMEFTsim_U35_MwScheme_UFO/couplings.py
+++ b/UFO_models/SMEFTsim_U35_MwScheme_UFO/couplings.py
@@ -3,9 +3,9 @@
 # Date: Wed 6 Jan 2021 14:20:54
 
 
-from object_library import all_couplings, Coupling
+from .object_library import all_couplings, Coupling
 
-from function_library import complexconjugate, re, im, csc, sec, acsc, asec, cot
+from .function_library import complexconjugate, re, im, csc, sec, acsc, asec, cot
 
 
 

--- a/UFO_models/SMEFTsim_U35_MwScheme_UFO/decays.py
+++ b/UFO_models/SMEFTsim_U35_MwScheme_UFO/decays.py
@@ -3,8 +3,8 @@
 # Date: Wed 6 Jan 2021 14:20:56
 
 
-from object_library import all_decays, Decay
-import particles as P
+from .object_library import all_decays, Decay
+from . import particles as P
 
 
 Decay_b = Decay(name = 'Decay_b',

--- a/UFO_models/SMEFTsim_U35_MwScheme_UFO/function_library.py
+++ b/UFO_models/SMEFTsim_U35_MwScheme_UFO/function_library.py
@@ -12,7 +12,7 @@ __date__ = "22 July 2010"
 __author__ = "claude.duhr@durham.ac.uk"
 
 import cmath
-from object_library import all_functions, Function
+from .object_library import all_functions, Function
 
 #
 # shortcuts for functions from cmath

--- a/UFO_models/SMEFTsim_U35_MwScheme_UFO/lorentz.py
+++ b/UFO_models/SMEFTsim_U35_MwScheme_UFO/lorentz.py
@@ -3,9 +3,9 @@
 # Date: Wed 6 Jan 2021 14:20:53
 
 
-from object_library import all_lorentz, Lorentz
+from .object_library import all_lorentz, Lorentz
 
-from function_library import complexconjugate, re, im, csc, sec, acsc, asec, cot
+from .function_library import complexconjugate, re, im, csc, sec, acsc, asec, cot
 try:
    import form_factors as ForFac 
 except ImportError:

--- a/UFO_models/SMEFTsim_U35_MwScheme_UFO/object_library.py
+++ b/UFO_models/SMEFTsim_U35_MwScheme_UFO/object_library.py
@@ -14,7 +14,7 @@ class UFOError(Exception):
         """Exception raised if when inconsistencies are detected in the UFO model."""
         pass
 
-class UFOBaseClass(object):
+class UFOBaseClass:
     """The class from which all FeynRules classes are derived."""
 
     require_args = []
@@ -133,7 +133,7 @@ class Particle(UFOBaseClass):
         if self.selfconjugate:
             raise Exception('%s has no anti particle.' % self.name) 
         outdic = {}
-        for k,v in self.__dict__.iteritems():
+        for k,v in self.__dict__.items():
             if k not in self.require_args_all:                
                 outdic[k] = -v
         if self.color in [1,8]:
@@ -265,9 +265,9 @@ class Coupling(UFOBaseClass):
                if not CTparam:
                    CTparam=param
                else:
-                   raise UFOError, "UFO does not support yet more than one occurence of CTParameters in the couplings values."
+                   raise UFOError("UFO does not support yet more than one occurence of CTParameters in the couplings values.")
            elif numberOfMatches>1:
-               raise UFOError, "UFO does not support yet more than one occurence of CTParameters in the couplings values."
+               raise UFOError("UFO does not support yet more than one occurence of CTParameters in the couplings values.")
 
         if not CTparam:
             if x==0:
@@ -299,7 +299,7 @@ class Lorentz(UFOBaseClass):
 
 all_functions = []
 
-class Function(object):
+class Function:
 
     def __init__(self, name, arguments, expression):
 
@@ -313,13 +313,13 @@ class Function(object):
     def __call__(self, *opt):
 
         for i, arg in enumerate(self.arguments):
-            exec('%s = %s' % (arg, opt[i] ))
+            exec(f'{arg} = {opt[i]}')
 
         return eval(self.expr)
 
 all_orders = []
 
-class CouplingOrder(object):
+class CouplingOrder:
 
     def __init__(self, name, expansion_order, hierarchy, perturbative_expansion = 0):
         

--- a/UFO_models/SMEFTsim_U35_MwScheme_UFO/parameters.py
+++ b/UFO_models/SMEFTsim_U35_MwScheme_UFO/parameters.py
@@ -4,10 +4,10 @@
 
 
 
-from object_library import all_parameters, Parameter
+from .object_library import all_parameters, Parameter
 
 
-from function_library import complexconjugate, re, im, csc, sec, acsc, asec, cot
+from .function_library import complexconjugate, re, im, csc, sec, acsc, asec, cot
 
 # This is a default parameter object representing 0.
 ZERO = Parameter(name = 'ZERO',

--- a/UFO_models/SMEFTsim_U35_MwScheme_UFO/particles.py
+++ b/UFO_models/SMEFTsim_U35_MwScheme_UFO/particles.py
@@ -3,11 +3,11 @@
 # Date: Tue 7 Apr 2020 10:47:23
 
 
-from __future__ import division
-from object_library import all_particles, Particle
-import parameters as Param
 
-import propagators as Prop
+from .object_library import all_particles, Particle
+from . import parameters as Param
+
+from . import propagators as Prop
 
 a = Particle(pdg_code = 22,
              name = 'a',

--- a/UFO_models/SMEFTsim_U35_MwScheme_UFO/propagators.py
+++ b/UFO_models/SMEFTsim_U35_MwScheme_UFO/propagators.py
@@ -2,7 +2,7 @@
 # Mathematica version: 8.0 for Mac OS X x86 (64-bit) (November 6, 2010)
 # Date: Mon 1 Oct 2012 14:58:26
 
-from object_library import all_propagators, Propagator
+from .object_library import all_propagators, Propagator
 
 
 # define only once the denominator since this is always the same

--- a/UFO_models/SMEFTsim_U35_MwScheme_UFO/vertices.py
+++ b/UFO_models/SMEFTsim_U35_MwScheme_UFO/vertices.py
@@ -3,10 +3,10 @@
 # Date: Wed 6 Jan 2021 14:20:52
 
 
-from object_library import all_vertices, Vertex
-import particles as P
-import couplings as C
-import lorentz as L
+from .object_library import all_vertices, Vertex
+from . import particles as P
+from . import couplings as C
+from . import lorentz as L
 
 
 V_1 = Vertex(name = 'V_1',

--- a/UFO_models/SMEFTsim_U35_MwScheme_UFO/write_param_card.py
+++ b/UFO_models/SMEFTsim_U35_MwScheme_UFO/write_param_card.py
@@ -1,10 +1,9 @@
-
 __date__ = "02 Aug 2012"
 __author__ = 'olivier.mattelaer@uclouvain.be'
 
-from function_library import *
+from .function_library import *
 
-class ParamCardWriter(object):
+class ParamCardWriter:
     
     header = \
     """######################################################################\n""" + \
@@ -15,7 +14,7 @@ class ParamCardWriter(object):
         """write a valid param_card.dat"""
         
         if not list_of_parameters:
-            from parameters import all_parameters
+            from .parameters import all_parameters
             list_of_parameters = [param for param in all_parameters if \
                                                        param.nature=='external']
         
@@ -33,7 +32,7 @@ class ParamCardWriter(object):
     def define_not_dep_param(self, list_of_parameters):
         """define self.dep_mass and self.dep_width in case that they are 
         requested in the param_card.dat"""
-        from particles import all_particles
+        from .particles import all_particles
         
         self.dep_mass = [(part, part.mass) for part in all_particles \
                             if part.pdg_code > 0 and \
@@ -67,7 +66,7 @@ class ParamCardWriter(object):
         """ """
         
         # list all lhablock
-        all_lhablock = set([param.lhablock for param in all_ext_param])
+        all_lhablock = {param.lhablock for param in all_ext_param}
         
         # ordonate lhablock alphabeticaly
         all_lhablock = list(all_lhablock)
@@ -108,9 +107,9 @@ class ParamCardWriter(object):
         
         lhacode=' '.join(['%3s' % key for key in param.lhacode])
         if lhablock != 'DECAY':
-            text = """  %s %e # %s \n""" % (lhacode, complex(param.value).real, param.name ) 
+            text = f"""  {lhacode} {complex(param.value).real:e} # {param.name} \n""" 
         else:
-            text = '''DECAY %s %e \n''' % (lhacode, complex(param.value).real)
+            text = f'''DECAY {lhacode} {complex(param.value).real:e} \n'''
         self.fsock.write(text) 
                     
 
@@ -118,10 +117,10 @@ class ParamCardWriter(object):
     
     def write_dep_param_block(self, lhablock):
         import cmath
-        from parameters import all_parameters
-        from particles import all_particles
+        from .parameters import all_parameters
+        from .particles import all_particles
         for parameter in all_parameters:
-            exec("%s = %s" % (parameter.name, parameter.value))
+            exec(f"{parameter.name} = {parameter.value}")
         text = "##  Not dependent paramater.\n"
         text += "## Those values should be edited following analytical the \n"
         text += "## analytical expression. Some generator could simply ignore \n"
@@ -177,9 +176,9 @@ class ParamCardWriter(object):
     
     def write_qnumber(self):
         """ write qnumber """
-        from particles import all_particles
-        import particles
-        print particles.__file__
+        from .particles import all_particles
+        from . import particles
+        print(particles.__file__)
         text="""#===========================================================\n"""
         text += """# QUANTUM NUMBERS OF NEW STATE(S) (NON SM PDG CODE)\n"""
         text += """#===========================================================\n\n"""
@@ -204,5 +203,5 @@ class ParamCardWriter(object):
             
 if '__main__' == __name__:
     ParamCardWriter('./param_card.dat', generic=True)
-    print 'write ./param_card.dat'
+    print('write ./param_card.dat')
     

--- a/UFO_models/SMEFTsim_U35_alphaScheme_UFO/CT_couplings.py
+++ b/UFO_models/SMEFTsim_U35_alphaScheme_UFO/CT_couplings.py
@@ -3,9 +3,9 @@
 # Date: Tue 18 Aug 2020 11:58:04
 
 
-from object_library import all_couplings, Coupling
+from .object_library import all_couplings, Coupling
 
-from function_library import complexconjugate, re, im, csc, sec, acsc, asec, cot
+from .function_library import complexconjugate, re, im, csc, sec, acsc, asec, cot
 
 
 

--- a/UFO_models/SMEFTsim_U35_alphaScheme_UFO/__init__.py
+++ b/UFO_models/SMEFTsim_U35_alphaScheme_UFO/__init__.py
@@ -1,14 +1,13 @@
+from . import particles
+from . import couplings
+from . import lorentz
+from . import parameters
+from . import vertices
+from . import coupling_orders
+from . import write_param_card
+from . import propagators
 
-import particles
-import couplings
-import lorentz
-import parameters
-import vertices
-import coupling_orders
-import write_param_card
-import propagators
-
-import function_library
+from . import function_library
 
 
 all_particles = particles.all_particles
@@ -21,7 +20,7 @@ all_functions = function_library.all_functions
 all_propagators = propagators.all_propagators
 
 try:
-   import decays
+   from . import decays
 except ImportError:
    pass
 else:

--- a/UFO_models/SMEFTsim_U35_alphaScheme_UFO/coupling_orders.py
+++ b/UFO_models/SMEFTsim_U35_alphaScheme_UFO/coupling_orders.py
@@ -3,7 +3,7 @@
 # Date: Tue 18 Aug 2020 11:58:03
 
 
-from object_library import all_orders, CouplingOrder
+from .object_library import all_orders, CouplingOrder
 
 
 QCD = CouplingOrder(name = 'QCD',

--- a/UFO_models/SMEFTsim_U35_alphaScheme_UFO/couplings.py
+++ b/UFO_models/SMEFTsim_U35_alphaScheme_UFO/couplings.py
@@ -3,9 +3,9 @@
 # Date: Wed 6 Jan 2021 16:20:39
 
 
-from object_library import all_couplings, Coupling
+from .object_library import all_couplings, Coupling
 
-from function_library import complexconjugate, re, im, csc, sec, acsc, asec, cot
+from .function_library import complexconjugate, re, im, csc, sec, acsc, asec, cot
 
 
 

--- a/UFO_models/SMEFTsim_U35_alphaScheme_UFO/decays.py
+++ b/UFO_models/SMEFTsim_U35_alphaScheme_UFO/decays.py
@@ -3,8 +3,8 @@
 # Date: Wed 6 Jan 2021 16:20:41
 
 
-from object_library import all_decays, Decay
-import particles as P
+from .object_library import all_decays, Decay
+from . import particles as P
 
 
 Decay_b = Decay(name = 'Decay_b',

--- a/UFO_models/SMEFTsim_U35_alphaScheme_UFO/function_library.py
+++ b/UFO_models/SMEFTsim_U35_alphaScheme_UFO/function_library.py
@@ -12,7 +12,7 @@ __date__ = "22 July 2010"
 __author__ = "claude.duhr@durham.ac.uk"
 
 import cmath
-from object_library import all_functions, Function
+from .object_library import all_functions, Function
 
 #
 # shortcuts for functions from cmath

--- a/UFO_models/SMEFTsim_U35_alphaScheme_UFO/lorentz.py
+++ b/UFO_models/SMEFTsim_U35_alphaScheme_UFO/lorentz.py
@@ -3,9 +3,9 @@
 # Date: Wed 6 Jan 2021 16:20:39
 
 
-from object_library import all_lorentz, Lorentz
+from .object_library import all_lorentz, Lorentz
 
-from function_library import complexconjugate, re, im, csc, sec, acsc, asec, cot
+from .function_library import complexconjugate, re, im, csc, sec, acsc, asec, cot
 try:
    import form_factors as ForFac 
 except ImportError:

--- a/UFO_models/SMEFTsim_U35_alphaScheme_UFO/object_library.py
+++ b/UFO_models/SMEFTsim_U35_alphaScheme_UFO/object_library.py
@@ -14,7 +14,7 @@ class UFOError(Exception):
         """Exception raised if when inconsistencies are detected in the UFO model."""
         pass
 
-class UFOBaseClass(object):
+class UFOBaseClass:
     """The class from which all FeynRules classes are derived."""
 
     require_args = []
@@ -133,7 +133,7 @@ class Particle(UFOBaseClass):
         if self.selfconjugate:
             raise Exception('%s has no anti particle.' % self.name) 
         outdic = {}
-        for k,v in self.__dict__.iteritems():
+        for k,v in self.__dict__.items():
             if k not in self.require_args_all:                
                 outdic[k] = -v
         if self.color in [1,8]:
@@ -265,9 +265,9 @@ class Coupling(UFOBaseClass):
                if not CTparam:
                    CTparam=param
                else:
-                   raise UFOError, "UFO does not support yet more than one occurence of CTParameters in the couplings values."
+                   raise UFOError("UFO does not support yet more than one occurence of CTParameters in the couplings values.")
            elif numberOfMatches>1:
-               raise UFOError, "UFO does not support yet more than one occurence of CTParameters in the couplings values."
+               raise UFOError("UFO does not support yet more than one occurence of CTParameters in the couplings values.")
 
         if not CTparam:
             if x==0:
@@ -299,7 +299,7 @@ class Lorentz(UFOBaseClass):
 
 all_functions = []
 
-class Function(object):
+class Function:
 
     def __init__(self, name, arguments, expression):
 
@@ -313,13 +313,13 @@ class Function(object):
     def __call__(self, *opt):
 
         for i, arg in enumerate(self.arguments):
-            exec('%s = %s' % (arg, opt[i] ))
+            exec(f'{arg} = {opt[i]}')
 
         return eval(self.expr)
 
 all_orders = []
 
-class CouplingOrder(object):
+class CouplingOrder:
 
     def __init__(self, name, expansion_order, hierarchy, perturbative_expansion = 0):
         

--- a/UFO_models/SMEFTsim_U35_alphaScheme_UFO/parameters.py
+++ b/UFO_models/SMEFTsim_U35_alphaScheme_UFO/parameters.py
@@ -4,10 +4,10 @@
 
 
 
-from object_library import all_parameters, Parameter
+from .object_library import all_parameters, Parameter
 
 
-from function_library import complexconjugate, re, im, csc, sec, acsc, asec, cot
+from .function_library import complexconjugate, re, im, csc, sec, acsc, asec, cot
 
 # This is a default parameter object representing 0.
 ZERO = Parameter(name = 'ZERO',

--- a/UFO_models/SMEFTsim_U35_alphaScheme_UFO/particles.py
+++ b/UFO_models/SMEFTsim_U35_alphaScheme_UFO/particles.py
@@ -3,11 +3,11 @@
 # Date: Tue 7 Apr 2020 10:47:23
 
 
-from __future__ import division
-from object_library import all_particles, Particle
-import parameters as Param
 
-import propagators as Prop
+from .object_library import all_particles, Particle
+from . import parameters as Param
+
+from . import propagators as Prop
 
 a = Particle(pdg_code = 22,
              name = 'a',

--- a/UFO_models/SMEFTsim_U35_alphaScheme_UFO/propagators.py
+++ b/UFO_models/SMEFTsim_U35_alphaScheme_UFO/propagators.py
@@ -2,7 +2,7 @@
 # Mathematica version: 8.0 for Mac OS X x86 (64-bit) (November 6, 2010)
 # Date: Mon 1 Oct 2012 14:58:26
 
-from object_library import all_propagators, Propagator
+from .object_library import all_propagators, Propagator
 
 
 # define only once the denominator since this is always the same

--- a/UFO_models/SMEFTsim_U35_alphaScheme_UFO/vertices.py
+++ b/UFO_models/SMEFTsim_U35_alphaScheme_UFO/vertices.py
@@ -3,10 +3,10 @@
 # Date: Wed 6 Jan 2021 16:20:38
 
 
-from object_library import all_vertices, Vertex
-import particles as P
-import couplings as C
-import lorentz as L
+from .object_library import all_vertices, Vertex
+from . import particles as P
+from . import couplings as C
+from . import lorentz as L
 
 
 V_1 = Vertex(name = 'V_1',

--- a/UFO_models/SMEFTsim_U35_alphaScheme_UFO/write_param_card.py
+++ b/UFO_models/SMEFTsim_U35_alphaScheme_UFO/write_param_card.py
@@ -1,10 +1,9 @@
-
 __date__ = "02 Aug 2012"
 __author__ = 'olivier.mattelaer@uclouvain.be'
 
-from function_library import *
+from .function_library import *
 
-class ParamCardWriter(object):
+class ParamCardWriter:
     
     header = \
     """######################################################################\n""" + \
@@ -15,7 +14,7 @@ class ParamCardWriter(object):
         """write a valid param_card.dat"""
         
         if not list_of_parameters:
-            from parameters import all_parameters
+            from .parameters import all_parameters
             list_of_parameters = [param for param in all_parameters if \
                                                        param.nature=='external']
         
@@ -33,7 +32,7 @@ class ParamCardWriter(object):
     def define_not_dep_param(self, list_of_parameters):
         """define self.dep_mass and self.dep_width in case that they are 
         requested in the param_card.dat"""
-        from particles import all_particles
+        from .particles import all_particles
         
         self.dep_mass = [(part, part.mass) for part in all_particles \
                             if part.pdg_code > 0 and \
@@ -67,7 +66,7 @@ class ParamCardWriter(object):
         """ """
         
         # list all lhablock
-        all_lhablock = set([param.lhablock for param in all_ext_param])
+        all_lhablock = {param.lhablock for param in all_ext_param}
         
         # ordonate lhablock alphabeticaly
         all_lhablock = list(all_lhablock)
@@ -108,9 +107,9 @@ class ParamCardWriter(object):
         
         lhacode=' '.join(['%3s' % key for key in param.lhacode])
         if lhablock != 'DECAY':
-            text = """  %s %e # %s \n""" % (lhacode, complex(param.value).real, param.name ) 
+            text = f"""  {lhacode} {complex(param.value).real:e} # {param.name} \n""" 
         else:
-            text = '''DECAY %s %e \n''' % (lhacode, complex(param.value).real)
+            text = f'''DECAY {lhacode} {complex(param.value).real:e} \n'''
         self.fsock.write(text) 
                     
 
@@ -118,10 +117,10 @@ class ParamCardWriter(object):
     
     def write_dep_param_block(self, lhablock):
         import cmath
-        from parameters import all_parameters
-        from particles import all_particles
+        from .parameters import all_parameters
+        from .particles import all_particles
         for parameter in all_parameters:
-            exec("%s = %s" % (parameter.name, parameter.value))
+            exec(f"{parameter.name} = {parameter.value}")
         text = "##  Not dependent paramater.\n"
         text += "## Those values should be edited following analytical the \n"
         text += "## analytical expression. Some generator could simply ignore \n"
@@ -177,9 +176,9 @@ class ParamCardWriter(object):
     
     def write_qnumber(self):
         """ write qnumber """
-        from particles import all_particles
-        import particles
-        print particles.__file__
+        from .particles import all_particles
+        from . import particles
+        print(particles.__file__)
         text="""#===========================================================\n"""
         text += """# QUANTUM NUMBERS OF NEW STATE(S) (NON SM PDG CODE)\n"""
         text += """#===========================================================\n\n"""
@@ -204,5 +203,5 @@ class ParamCardWriter(object):
             
 if '__main__' == __name__:
     ParamCardWriter('./param_card.dat', generic=True)
-    print 'write ./param_card.dat'
+    print('write ./param_card.dat')
     

--- a/UFO_models/SMEFTsim_general_MwScheme_UFO/CT_couplings.py
+++ b/UFO_models/SMEFTsim_general_MwScheme_UFO/CT_couplings.py
@@ -3,9 +3,9 @@
 # Date: Sat 1 Aug 2020 10:51:16
 
 
-from object_library import all_couplings, Coupling
+from .object_library import all_couplings, Coupling
 
-from function_library import complexconjugate, re, im, csc, sec, acsc, asec, cot
+from .function_library import complexconjugate, re, im, csc, sec, acsc, asec, cot
 
 
 

--- a/UFO_models/SMEFTsim_general_MwScheme_UFO/__init__.py
+++ b/UFO_models/SMEFTsim_general_MwScheme_UFO/__init__.py
@@ -1,14 +1,13 @@
+from . import particles
+from . import couplings
+from . import lorentz
+from . import parameters
+from . import vertices
+from . import coupling_orders
+from . import write_param_card
+from . import propagators
 
-import particles
-import couplings
-import lorentz
-import parameters
-import vertices
-import coupling_orders
-import write_param_card
-import propagators
-
-import function_library
+from . import function_library
 
 
 all_particles = particles.all_particles
@@ -21,7 +20,7 @@ all_functions = function_library.all_functions
 all_propagators = propagators.all_propagators
 
 try:
-   import decays
+   from . import decays
 except ImportError:
    pass
 else:

--- a/UFO_models/SMEFTsim_general_MwScheme_UFO/coupling_orders.py
+++ b/UFO_models/SMEFTsim_general_MwScheme_UFO/coupling_orders.py
@@ -3,7 +3,7 @@
 # Date: Sat 1 Aug 2020 10:50:12
 
 
-from object_library import all_orders, CouplingOrder
+from .object_library import all_orders, CouplingOrder
 
 
 QCD = CouplingOrder(name = 'QCD',

--- a/UFO_models/SMEFTsim_general_MwScheme_UFO/couplings.py
+++ b/UFO_models/SMEFTsim_general_MwScheme_UFO/couplings.py
@@ -3,9 +3,9 @@
 # Date: Sat 9 Jan 2021 13:22:48
 
 
-from object_library import all_couplings, Coupling
+from .object_library import all_couplings, Coupling
 
-from function_library import complexconjugate, re, im, csc, sec, acsc, asec, cot
+from .function_library import complexconjugate, re, im, csc, sec, acsc, asec, cot
 
 
 

--- a/UFO_models/SMEFTsim_general_MwScheme_UFO/function_library.py
+++ b/UFO_models/SMEFTsim_general_MwScheme_UFO/function_library.py
@@ -12,7 +12,7 @@ __date__ = "22 July 2010"
 __author__ = "claude.duhr@durham.ac.uk"
 
 import cmath
-from object_library import all_functions, Function
+from .object_library import all_functions, Function
 
 #
 # shortcuts for functions from cmath

--- a/UFO_models/SMEFTsim_general_MwScheme_UFO/lorentz.py
+++ b/UFO_models/SMEFTsim_general_MwScheme_UFO/lorentz.py
@@ -3,9 +3,9 @@
 # Date: Sat 9 Jan 2021 13:22:47
 
 
-from object_library import all_lorentz, Lorentz
+from .object_library import all_lorentz, Lorentz
 
-from function_library import complexconjugate, re, im, csc, sec, acsc, asec, cot
+from .function_library import complexconjugate, re, im, csc, sec, acsc, asec, cot
 try:
    import form_factors as ForFac 
 except ImportError:

--- a/UFO_models/SMEFTsim_general_MwScheme_UFO/object_library.py
+++ b/UFO_models/SMEFTsim_general_MwScheme_UFO/object_library.py
@@ -14,7 +14,7 @@ class UFOError(Exception):
         """Exception raised if when inconsistencies are detected in the UFO model."""
         pass
 
-class UFOBaseClass(object):
+class UFOBaseClass:
     """The class from which all FeynRules classes are derived."""
 
     require_args = []
@@ -133,7 +133,7 @@ class Particle(UFOBaseClass):
         if self.selfconjugate:
             raise Exception('%s has no anti particle.' % self.name) 
         outdic = {}
-        for k,v in self.__dict__.iteritems():
+        for k,v in self.__dict__.items():
             if k not in self.require_args_all:                
                 outdic[k] = -v
         if self.color in [1,8]:
@@ -265,9 +265,9 @@ class Coupling(UFOBaseClass):
                if not CTparam:
                    CTparam=param
                else:
-                   raise UFOError, "UFO does not support yet more than one occurence of CTParameters in the couplings values."
+                   raise UFOError("UFO does not support yet more than one occurence of CTParameters in the couplings values.")
            elif numberOfMatches>1:
-               raise UFOError, "UFO does not support yet more than one occurence of CTParameters in the couplings values."
+               raise UFOError("UFO does not support yet more than one occurence of CTParameters in the couplings values.")
 
         if not CTparam:
             if x==0:
@@ -299,7 +299,7 @@ class Lorentz(UFOBaseClass):
 
 all_functions = []
 
-class Function(object):
+class Function:
 
     def __init__(self, name, arguments, expression):
 
@@ -313,13 +313,13 @@ class Function(object):
     def __call__(self, *opt):
 
         for i, arg in enumerate(self.arguments):
-            exec('%s = %s' % (arg, opt[i] ))
+            exec(f'{arg} = {opt[i]}')
 
         return eval(self.expr)
 
 all_orders = []
 
-class CouplingOrder(object):
+class CouplingOrder:
 
     def __init__(self, name, expansion_order, hierarchy, perturbative_expansion = 0):
         

--- a/UFO_models/SMEFTsim_general_MwScheme_UFO/parameters.py
+++ b/UFO_models/SMEFTsim_general_MwScheme_UFO/parameters.py
@@ -4,10 +4,10 @@
 
 
 
-from object_library import all_parameters, Parameter
+from .object_library import all_parameters, Parameter
 
 
-from function_library import complexconjugate, re, im, csc, sec, acsc, asec, cot
+from .function_library import complexconjugate, re, im, csc, sec, acsc, asec, cot
 
 # This is a default parameter object representing 0.
 ZERO = Parameter(name = 'ZERO',

--- a/UFO_models/SMEFTsim_general_MwScheme_UFO/particles.py
+++ b/UFO_models/SMEFTsim_general_MwScheme_UFO/particles.py
@@ -3,11 +3,11 @@
 # Date: Tue 7 Apr 2020 10:47:23
 
 
-from __future__ import division
-from object_library import all_particles, Particle
-import parameters as Param
 
-import propagators as Prop
+from .object_library import all_particles, Particle
+from . import parameters as Param
+
+from . import propagators as Prop
 
 a = Particle(pdg_code = 22,
              name = 'a',

--- a/UFO_models/SMEFTsim_general_MwScheme_UFO/propagators.py
+++ b/UFO_models/SMEFTsim_general_MwScheme_UFO/propagators.py
@@ -2,7 +2,7 @@
 # Mathematica version: 8.0 for Mac OS X x86 (64-bit) (November 6, 2010)
 # Date: Mon 1 Oct 2012 14:58:26
 
-from object_library import all_propagators, Propagator
+from .object_library import all_propagators, Propagator
 
 
 # define only once the denominator since this is always the same

--- a/UFO_models/SMEFTsim_general_MwScheme_UFO/vertices.py
+++ b/UFO_models/SMEFTsim_general_MwScheme_UFO/vertices.py
@@ -3,10 +3,10 @@
 # Date: Sat 9 Jan 2021 13:22:45
 
 
-from object_library import all_vertices, Vertex
-import particles as P
-import couplings as C
-import lorentz as L
+from .object_library import all_vertices, Vertex
+from . import particles as P
+from . import couplings as C
+from . import lorentz as L
 
 
 V_1 = Vertex(name = 'V_1',

--- a/UFO_models/SMEFTsim_general_MwScheme_UFO/write_param_card.py
+++ b/UFO_models/SMEFTsim_general_MwScheme_UFO/write_param_card.py
@@ -1,10 +1,9 @@
-
 __date__ = "02 Aug 2012"
 __author__ = 'olivier.mattelaer@uclouvain.be'
 
-from function_library import *
+from .function_library import *
 
-class ParamCardWriter(object):
+class ParamCardWriter:
     
     header = \
     """######################################################################\n""" + \
@@ -15,7 +14,7 @@ class ParamCardWriter(object):
         """write a valid param_card.dat"""
         
         if not list_of_parameters:
-            from parameters import all_parameters
+            from .parameters import all_parameters
             list_of_parameters = [param for param in all_parameters if \
                                                        param.nature=='external']
         
@@ -33,7 +32,7 @@ class ParamCardWriter(object):
     def define_not_dep_param(self, list_of_parameters):
         """define self.dep_mass and self.dep_width in case that they are 
         requested in the param_card.dat"""
-        from particles import all_particles
+        from .particles import all_particles
         
         self.dep_mass = [(part, part.mass) for part in all_particles \
                             if part.pdg_code > 0 and \
@@ -67,7 +66,7 @@ class ParamCardWriter(object):
         """ """
         
         # list all lhablock
-        all_lhablock = set([param.lhablock for param in all_ext_param])
+        all_lhablock = {param.lhablock for param in all_ext_param}
         
         # ordonate lhablock alphabeticaly
         all_lhablock = list(all_lhablock)
@@ -108,9 +107,9 @@ class ParamCardWriter(object):
         
         lhacode=' '.join(['%3s' % key for key in param.lhacode])
         if lhablock != 'DECAY':
-            text = """  %s %e # %s \n""" % (lhacode, complex(param.value).real, param.name ) 
+            text = f"""  {lhacode} {complex(param.value).real:e} # {param.name} \n""" 
         else:
-            text = '''DECAY %s %e \n''' % (lhacode, complex(param.value).real)
+            text = f'''DECAY {lhacode} {complex(param.value).real:e} \n'''
         self.fsock.write(text) 
                     
 
@@ -118,10 +117,10 @@ class ParamCardWriter(object):
     
     def write_dep_param_block(self, lhablock):
         import cmath
-        from parameters import all_parameters
-        from particles import all_particles
+        from .parameters import all_parameters
+        from .particles import all_particles
         for parameter in all_parameters:
-            exec("%s = %s" % (parameter.name, parameter.value))
+            exec(f"{parameter.name} = {parameter.value}")
         text = "##  Not dependent paramater.\n"
         text += "## Those values should be edited following analytical the \n"
         text += "## analytical expression. Some generator could simply ignore \n"
@@ -177,9 +176,9 @@ class ParamCardWriter(object):
     
     def write_qnumber(self):
         """ write qnumber """
-        from particles import all_particles
-        import particles
-        print particles.__file__
+        from .particles import all_particles
+        from . import particles
+        print(particles.__file__)
         text="""#===========================================================\n"""
         text += """# QUANTUM NUMBERS OF NEW STATE(S) (NON SM PDG CODE)\n"""
         text += """#===========================================================\n\n"""
@@ -204,5 +203,5 @@ class ParamCardWriter(object):
             
 if '__main__' == __name__:
     ParamCardWriter('./param_card.dat', generic=True)
-    print 'write ./param_card.dat'
+    print('write ./param_card.dat')
     

--- a/UFO_models/SMEFTsim_general_alphaScheme_UFO/CT_couplings.py
+++ b/UFO_models/SMEFTsim_general_alphaScheme_UFO/CT_couplings.py
@@ -3,9 +3,9 @@
 # Date: Sun 2 Aug 2020 07:37:06
 
 
-from object_library import all_couplings, Coupling
+from .object_library import all_couplings, Coupling
 
-from function_library import complexconjugate, re, im, csc, sec, acsc, asec, cot
+from .function_library import complexconjugate, re, im, csc, sec, acsc, asec, cot
 
 
 

--- a/UFO_models/SMEFTsim_general_alphaScheme_UFO/__init__.py
+++ b/UFO_models/SMEFTsim_general_alphaScheme_UFO/__init__.py
@@ -1,14 +1,13 @@
+from . import particles
+from . import couplings
+from . import lorentz
+from . import parameters
+from . import vertices
+from . import coupling_orders
+from . import write_param_card
+from . import propagators
 
-import particles
-import couplings
-import lorentz
-import parameters
-import vertices
-import coupling_orders
-import write_param_card
-import propagators
-
-import function_library
+from . import function_library
 
 
 all_particles = particles.all_particles
@@ -21,7 +20,7 @@ all_functions = function_library.all_functions
 all_propagators = propagators.all_propagators
 
 try:
-   import decays
+   from . import decays
 except ImportError:
    pass
 else:

--- a/UFO_models/SMEFTsim_general_alphaScheme_UFO/coupling_orders.py
+++ b/UFO_models/SMEFTsim_general_alphaScheme_UFO/coupling_orders.py
@@ -3,7 +3,7 @@
 # Date: Sun 2 Aug 2020 07:36:02
 
 
-from object_library import all_orders, CouplingOrder
+from .object_library import all_orders, CouplingOrder
 
 
 QCD = CouplingOrder(name = 'QCD',

--- a/UFO_models/SMEFTsim_general_alphaScheme_UFO/couplings.py
+++ b/UFO_models/SMEFTsim_general_alphaScheme_UFO/couplings.py
@@ -3,9 +3,9 @@
 # Date: Wed 13 Jan 2021 05:30:39
 
 
-from object_library import all_couplings, Coupling
+from .object_library import all_couplings, Coupling
 
-from function_library import complexconjugate, re, im, csc, sec, acsc, asec, cot
+from .function_library import complexconjugate, re, im, csc, sec, acsc, asec, cot
 
 
 

--- a/UFO_models/SMEFTsim_general_alphaScheme_UFO/function_library.py
+++ b/UFO_models/SMEFTsim_general_alphaScheme_UFO/function_library.py
@@ -12,7 +12,7 @@ __date__ = "22 July 2010"
 __author__ = "claude.duhr@durham.ac.uk"
 
 import cmath
-from object_library import all_functions, Function
+from .object_library import all_functions, Function
 
 #
 # shortcuts for functions from cmath

--- a/UFO_models/SMEFTsim_general_alphaScheme_UFO/lorentz.py
+++ b/UFO_models/SMEFTsim_general_alphaScheme_UFO/lorentz.py
@@ -3,9 +3,9 @@
 # Date: Wed 13 Jan 2021 05:30:38
 
 
-from object_library import all_lorentz, Lorentz
+from .object_library import all_lorentz, Lorentz
 
-from function_library import complexconjugate, re, im, csc, sec, acsc, asec, cot
+from .function_library import complexconjugate, re, im, csc, sec, acsc, asec, cot
 try:
    import form_factors as ForFac 
 except ImportError:

--- a/UFO_models/SMEFTsim_general_alphaScheme_UFO/object_library.py
+++ b/UFO_models/SMEFTsim_general_alphaScheme_UFO/object_library.py
@@ -14,7 +14,7 @@ class UFOError(Exception):
         """Exception raised if when inconsistencies are detected in the UFO model."""
         pass
 
-class UFOBaseClass(object):
+class UFOBaseClass:
     """The class from which all FeynRules classes are derived."""
 
     require_args = []
@@ -133,7 +133,7 @@ class Particle(UFOBaseClass):
         if self.selfconjugate:
             raise Exception('%s has no anti particle.' % self.name) 
         outdic = {}
-        for k,v in self.__dict__.iteritems():
+        for k,v in self.__dict__.items():
             if k not in self.require_args_all:                
                 outdic[k] = -v
         if self.color in [1,8]:
@@ -265,9 +265,9 @@ class Coupling(UFOBaseClass):
                if not CTparam:
                    CTparam=param
                else:
-                   raise UFOError, "UFO does not support yet more than one occurence of CTParameters in the couplings values."
+                   raise UFOError("UFO does not support yet more than one occurence of CTParameters in the couplings values.")
            elif numberOfMatches>1:
-               raise UFOError, "UFO does not support yet more than one occurence of CTParameters in the couplings values."
+               raise UFOError("UFO does not support yet more than one occurence of CTParameters in the couplings values.")
 
         if not CTparam:
             if x==0:
@@ -299,7 +299,7 @@ class Lorentz(UFOBaseClass):
 
 all_functions = []
 
-class Function(object):
+class Function:
 
     def __init__(self, name, arguments, expression):
 
@@ -313,13 +313,13 @@ class Function(object):
     def __call__(self, *opt):
 
         for i, arg in enumerate(self.arguments):
-            exec('%s = %s' % (arg, opt[i] ))
+            exec(f'{arg} = {opt[i]}')
 
         return eval(self.expr)
 
 all_orders = []
 
-class CouplingOrder(object):
+class CouplingOrder:
 
     def __init__(self, name, expansion_order, hierarchy, perturbative_expansion = 0):
         

--- a/UFO_models/SMEFTsim_general_alphaScheme_UFO/parameters.py
+++ b/UFO_models/SMEFTsim_general_alphaScheme_UFO/parameters.py
@@ -4,10 +4,10 @@
 
 
 
-from object_library import all_parameters, Parameter
+from .object_library import all_parameters, Parameter
 
 
-from function_library import complexconjugate, re, im, csc, sec, acsc, asec, cot
+from .function_library import complexconjugate, re, im, csc, sec, acsc, asec, cot
 
 # This is a default parameter object representing 0.
 ZERO = Parameter(name = 'ZERO',

--- a/UFO_models/SMEFTsim_general_alphaScheme_UFO/particles.py
+++ b/UFO_models/SMEFTsim_general_alphaScheme_UFO/particles.py
@@ -3,11 +3,11 @@
 # Date: Tue 7 Apr 2020 10:47:23
 
 
-from __future__ import division
-from object_library import all_particles, Particle
-import parameters as Param
 
-import propagators as Prop
+from .object_library import all_particles, Particle
+from . import parameters as Param
+
+from . import propagators as Prop
 
 a = Particle(pdg_code = 22,
              name = 'a',

--- a/UFO_models/SMEFTsim_general_alphaScheme_UFO/propagators.py
+++ b/UFO_models/SMEFTsim_general_alphaScheme_UFO/propagators.py
@@ -2,7 +2,7 @@
 # Mathematica version: 8.0 for Mac OS X x86 (64-bit) (November 6, 2010)
 # Date: Mon 1 Oct 2012 14:58:26
 
-from object_library import all_propagators, Propagator
+from .object_library import all_propagators, Propagator
 
 
 # define only once the denominator since this is always the same

--- a/UFO_models/SMEFTsim_general_alphaScheme_UFO/vertices.py
+++ b/UFO_models/SMEFTsim_general_alphaScheme_UFO/vertices.py
@@ -3,10 +3,10 @@
 # Date: Wed 13 Jan 2021 05:30:35
 
 
-from object_library import all_vertices, Vertex
-import particles as P
-import couplings as C
-import lorentz as L
+from .object_library import all_vertices, Vertex
+from . import particles as P
+from . import couplings as C
+from . import lorentz as L
 
 
 V_1 = Vertex(name = 'V_1',

--- a/UFO_models/SMEFTsim_general_alphaScheme_UFO/write_param_card.py
+++ b/UFO_models/SMEFTsim_general_alphaScheme_UFO/write_param_card.py
@@ -1,10 +1,9 @@
-
 __date__ = "02 Aug 2012"
 __author__ = 'olivier.mattelaer@uclouvain.be'
 
-from function_library import *
+from .function_library import *
 
-class ParamCardWriter(object):
+class ParamCardWriter:
     
     header = \
     """######################################################################\n""" + \
@@ -15,7 +14,7 @@ class ParamCardWriter(object):
         """write a valid param_card.dat"""
         
         if not list_of_parameters:
-            from parameters import all_parameters
+            from .parameters import all_parameters
             list_of_parameters = [param for param in all_parameters if \
                                                        param.nature=='external']
         
@@ -33,7 +32,7 @@ class ParamCardWriter(object):
     def define_not_dep_param(self, list_of_parameters):
         """define self.dep_mass and self.dep_width in case that they are 
         requested in the param_card.dat"""
-        from particles import all_particles
+        from .particles import all_particles
         
         self.dep_mass = [(part, part.mass) for part in all_particles \
                             if part.pdg_code > 0 and \
@@ -67,7 +66,7 @@ class ParamCardWriter(object):
         """ """
         
         # list all lhablock
-        all_lhablock = set([param.lhablock for param in all_ext_param])
+        all_lhablock = {param.lhablock for param in all_ext_param}
         
         # ordonate lhablock alphabeticaly
         all_lhablock = list(all_lhablock)
@@ -108,9 +107,9 @@ class ParamCardWriter(object):
         
         lhacode=' '.join(['%3s' % key for key in param.lhacode])
         if lhablock != 'DECAY':
-            text = """  %s %e # %s \n""" % (lhacode, complex(param.value).real, param.name ) 
+            text = f"""  {lhacode} {complex(param.value).real:e} # {param.name} \n""" 
         else:
-            text = '''DECAY %s %e \n''' % (lhacode, complex(param.value).real)
+            text = f'''DECAY {lhacode} {complex(param.value).real:e} \n'''
         self.fsock.write(text) 
                     
 
@@ -118,10 +117,10 @@ class ParamCardWriter(object):
     
     def write_dep_param_block(self, lhablock):
         import cmath
-        from parameters import all_parameters
-        from particles import all_particles
+        from .parameters import all_parameters
+        from .particles import all_particles
         for parameter in all_parameters:
-            exec("%s = %s" % (parameter.name, parameter.value))
+            exec(f"{parameter.name} = {parameter.value}")
         text = "##  Not dependent paramater.\n"
         text += "## Those values should be edited following analytical the \n"
         text += "## analytical expression. Some generator could simply ignore \n"
@@ -177,9 +176,9 @@ class ParamCardWriter(object):
     
     def write_qnumber(self):
         """ write qnumber """
-        from particles import all_particles
-        import particles
-        print particles.__file__
+        from .particles import all_particles
+        from . import particles
+        print(particles.__file__)
         text="""#===========================================================\n"""
         text += """# QUANTUM NUMBERS OF NEW STATE(S) (NON SM PDG CODE)\n"""
         text += """#===========================================================\n\n"""
@@ -204,5 +203,5 @@ class ParamCardWriter(object):
             
 if '__main__' == __name__:
     ParamCardWriter('./param_card.dat', generic=True)
-    print 'write ./param_card.dat'
+    print('write ./param_card.dat')
     

--- a/UFO_models/SMEFTsim_topU3l_MwScheme_UFO/CT_couplings.py
+++ b/UFO_models/SMEFTsim_topU3l_MwScheme_UFO/CT_couplings.py
@@ -3,9 +3,9 @@
 # Date: Tue 18 Aug 2020 15:03:52
 
 
-from object_library import all_couplings, Coupling
+from .object_library import all_couplings, Coupling
 
-from function_library import complexconjugate, re, im, csc, sec, acsc, asec, cot
+from .function_library import complexconjugate, re, im, csc, sec, acsc, asec, cot
 
 
 

--- a/UFO_models/SMEFTsim_topU3l_MwScheme_UFO/__init__.py
+++ b/UFO_models/SMEFTsim_topU3l_MwScheme_UFO/__init__.py
@@ -1,14 +1,13 @@
+from . import particles
+from . import couplings
+from . import lorentz
+from . import parameters
+from . import vertices
+from . import coupling_orders
+from . import write_param_card
+from . import propagators
 
-import particles
-import couplings
-import lorentz
-import parameters
-import vertices
-import coupling_orders
-import write_param_card
-import propagators
-
-import function_library
+from . import function_library
 
 
 all_particles = particles.all_particles
@@ -21,7 +20,7 @@ all_functions = function_library.all_functions
 all_propagators = propagators.all_propagators
 
 try:
-   import decays
+   from . import decays
 except ImportError:
    pass
 else:

--- a/UFO_models/SMEFTsim_topU3l_MwScheme_UFO/coupling_orders.py
+++ b/UFO_models/SMEFTsim_topU3l_MwScheme_UFO/coupling_orders.py
@@ -3,7 +3,7 @@
 # Date: Tue 18 Aug 2020 15:03:51
 
 
-from object_library import all_orders, CouplingOrder
+from .object_library import all_orders, CouplingOrder
 
 
 QCD = CouplingOrder(name = 'QCD',

--- a/UFO_models/SMEFTsim_topU3l_MwScheme_UFO/couplings.py
+++ b/UFO_models/SMEFTsim_topU3l_MwScheme_UFO/couplings.py
@@ -3,9 +3,9 @@
 # Date: Thu 7 Jan 2021 13:56:44
 
 
-from object_library import all_couplings, Coupling
+from .object_library import all_couplings, Coupling
 
-from function_library import complexconjugate, re, im, csc, sec, acsc, asec, cot
+from .function_library import complexconjugate, re, im, csc, sec, acsc, asec, cot
 
 
 

--- a/UFO_models/SMEFTsim_topU3l_MwScheme_UFO/decays.py
+++ b/UFO_models/SMEFTsim_topU3l_MwScheme_UFO/decays.py
@@ -3,8 +3,8 @@
 # Date: Thu 7 Jan 2021 13:56:44
 
 
-from object_library import all_decays, Decay
-import particles as P
+from .object_library import all_decays, Decay
+from . import particles as P
 
 
 Decay_b = Decay(name = 'Decay_b',

--- a/UFO_models/SMEFTsim_topU3l_MwScheme_UFO/function_library.py
+++ b/UFO_models/SMEFTsim_topU3l_MwScheme_UFO/function_library.py
@@ -12,7 +12,7 @@ __date__ = "22 July 2010"
 __author__ = "claude.duhr@durham.ac.uk"
 
 import cmath
-from object_library import all_functions, Function
+from .object_library import all_functions, Function
 
 #
 # shortcuts for functions from cmath

--- a/UFO_models/SMEFTsim_topU3l_MwScheme_UFO/lorentz.py
+++ b/UFO_models/SMEFTsim_topU3l_MwScheme_UFO/lorentz.py
@@ -3,9 +3,9 @@
 # Date: Thu 7 Jan 2021 13:56:43
 
 
-from object_library import all_lorentz, Lorentz
+from .object_library import all_lorentz, Lorentz
 
-from function_library import complexconjugate, re, im, csc, sec, acsc, asec, cot
+from .function_library import complexconjugate, re, im, csc, sec, acsc, asec, cot
 try:
    import form_factors as ForFac 
 except ImportError:

--- a/UFO_models/SMEFTsim_topU3l_MwScheme_UFO/object_library.py
+++ b/UFO_models/SMEFTsim_topU3l_MwScheme_UFO/object_library.py
@@ -14,7 +14,7 @@ class UFOError(Exception):
         """Exception raised if when inconsistencies are detected in the UFO model."""
         pass
 
-class UFOBaseClass(object):
+class UFOBaseClass:
     """The class from which all FeynRules classes are derived."""
 
     require_args = []
@@ -133,7 +133,7 @@ class Particle(UFOBaseClass):
         if self.selfconjugate:
             raise Exception('%s has no anti particle.' % self.name) 
         outdic = {}
-        for k,v in self.__dict__.iteritems():
+        for k,v in self.__dict__.items():
             if k not in self.require_args_all:                
                 outdic[k] = -v
         if self.color in [1,8]:
@@ -265,9 +265,9 @@ class Coupling(UFOBaseClass):
                if not CTparam:
                    CTparam=param
                else:
-                   raise UFOError, "UFO does not support yet more than one occurence of CTParameters in the couplings values."
+                   raise UFOError("UFO does not support yet more than one occurence of CTParameters in the couplings values.")
            elif numberOfMatches>1:
-               raise UFOError, "UFO does not support yet more than one occurence of CTParameters in the couplings values."
+               raise UFOError("UFO does not support yet more than one occurence of CTParameters in the couplings values.")
 
         if not CTparam:
             if x==0:
@@ -299,7 +299,7 @@ class Lorentz(UFOBaseClass):
 
 all_functions = []
 
-class Function(object):
+class Function:
 
     def __init__(self, name, arguments, expression):
 
@@ -313,13 +313,13 @@ class Function(object):
     def __call__(self, *opt):
 
         for i, arg in enumerate(self.arguments):
-            exec('%s = %s' % (arg, opt[i] ))
+            exec(f'{arg} = {opt[i]}')
 
         return eval(self.expr)
 
 all_orders = []
 
-class CouplingOrder(object):
+class CouplingOrder:
 
     def __init__(self, name, expansion_order, hierarchy, perturbative_expansion = 0):
         

--- a/UFO_models/SMEFTsim_topU3l_MwScheme_UFO/parameters.py
+++ b/UFO_models/SMEFTsim_topU3l_MwScheme_UFO/parameters.py
@@ -4,10 +4,10 @@
 
 
 
-from object_library import all_parameters, Parameter
+from .object_library import all_parameters, Parameter
 
 
-from function_library import complexconjugate, re, im, csc, sec, acsc, asec, cot
+from .function_library import complexconjugate, re, im, csc, sec, acsc, asec, cot
 
 # This is a default parameter object representing 0.
 ZERO = Parameter(name = 'ZERO',

--- a/UFO_models/SMEFTsim_topU3l_MwScheme_UFO/particles.py
+++ b/UFO_models/SMEFTsim_topU3l_MwScheme_UFO/particles.py
@@ -3,11 +3,11 @@
 # Date: Tue 7 Apr 2020 10:47:23
 
 
-from __future__ import division
-from object_library import all_particles, Particle
-import parameters as Param
 
-import propagators as Prop
+from .object_library import all_particles, Particle
+from . import parameters as Param
+
+from . import propagators as Prop
 
 a = Particle(pdg_code = 22,
              name = 'a',

--- a/UFO_models/SMEFTsim_topU3l_MwScheme_UFO/propagators.py
+++ b/UFO_models/SMEFTsim_topU3l_MwScheme_UFO/propagators.py
@@ -2,7 +2,7 @@
 # Mathematica version: 8.0 for Mac OS X x86 (64-bit) (November 6, 2010)
 # Date: Mon 1 Oct 2012 14:58:26
 
-from object_library import all_propagators, Propagator
+from .object_library import all_propagators, Propagator
 
 
 # define only once the denominator since this is always the same

--- a/UFO_models/SMEFTsim_topU3l_MwScheme_UFO/vertices.py
+++ b/UFO_models/SMEFTsim_topU3l_MwScheme_UFO/vertices.py
@@ -3,10 +3,10 @@
 # Date: Thu 7 Jan 2021 13:56:43
 
 
-from object_library import all_vertices, Vertex
-import particles as P
-import couplings as C
-import lorentz as L
+from .object_library import all_vertices, Vertex
+from . import particles as P
+from . import couplings as C
+from . import lorentz as L
 
 
 V_1 = Vertex(name = 'V_1',

--- a/UFO_models/SMEFTsim_topU3l_MwScheme_UFO/write_param_card.py
+++ b/UFO_models/SMEFTsim_topU3l_MwScheme_UFO/write_param_card.py
@@ -1,10 +1,9 @@
-
 __date__ = "02 Aug 2012"
 __author__ = 'olivier.mattelaer@uclouvain.be'
 
-from function_library import *
+from .function_library import *
 
-class ParamCardWriter(object):
+class ParamCardWriter:
     
     header = \
     """######################################################################\n""" + \
@@ -15,7 +14,7 @@ class ParamCardWriter(object):
         """write a valid param_card.dat"""
         
         if not list_of_parameters:
-            from parameters import all_parameters
+            from .parameters import all_parameters
             list_of_parameters = [param for param in all_parameters if \
                                                        param.nature=='external']
         
@@ -33,7 +32,7 @@ class ParamCardWriter(object):
     def define_not_dep_param(self, list_of_parameters):
         """define self.dep_mass and self.dep_width in case that they are 
         requested in the param_card.dat"""
-        from particles import all_particles
+        from .particles import all_particles
         
         self.dep_mass = [(part, part.mass) for part in all_particles \
                             if part.pdg_code > 0 and \
@@ -67,7 +66,7 @@ class ParamCardWriter(object):
         """ """
         
         # list all lhablock
-        all_lhablock = set([param.lhablock for param in all_ext_param])
+        all_lhablock = {param.lhablock for param in all_ext_param}
         
         # ordonate lhablock alphabeticaly
         all_lhablock = list(all_lhablock)
@@ -108,9 +107,9 @@ class ParamCardWriter(object):
         
         lhacode=' '.join(['%3s' % key for key in param.lhacode])
         if lhablock != 'DECAY':
-            text = """  %s %e # %s \n""" % (lhacode, complex(param.value).real, param.name ) 
+            text = f"""  {lhacode} {complex(param.value).real:e} # {param.name} \n""" 
         else:
-            text = '''DECAY %s %e \n''' % (lhacode, complex(param.value).real)
+            text = f'''DECAY {lhacode} {complex(param.value).real:e} \n'''
         self.fsock.write(text) 
                     
 
@@ -118,10 +117,10 @@ class ParamCardWriter(object):
     
     def write_dep_param_block(self, lhablock):
         import cmath
-        from parameters import all_parameters
-        from particles import all_particles
+        from .parameters import all_parameters
+        from .particles import all_particles
         for parameter in all_parameters:
-            exec("%s = %s" % (parameter.name, parameter.value))
+            exec(f"{parameter.name} = {parameter.value}")
         text = "##  Not dependent paramater.\n"
         text += "## Those values should be edited following analytical the \n"
         text += "## analytical expression. Some generator could simply ignore \n"
@@ -177,9 +176,9 @@ class ParamCardWriter(object):
     
     def write_qnumber(self):
         """ write qnumber """
-        from particles import all_particles
-        import particles
-        print particles.__file__
+        from .particles import all_particles
+        from . import particles
+        print(particles.__file__)
         text="""#===========================================================\n"""
         text += """# QUANTUM NUMBERS OF NEW STATE(S) (NON SM PDG CODE)\n"""
         text += """#===========================================================\n\n"""
@@ -204,5 +203,5 @@ class ParamCardWriter(object):
             
 if '__main__' == __name__:
     ParamCardWriter('./param_card.dat', generic=True)
-    print 'write ./param_card.dat'
+    print('write ./param_card.dat')
     

--- a/UFO_models/SMEFTsim_topU3l_alphaScheme_UFO/CT_couplings.py
+++ b/UFO_models/SMEFTsim_topU3l_alphaScheme_UFO/CT_couplings.py
@@ -3,9 +3,9 @@
 # Date: Tue 18 Aug 2020 15:46:10
 
 
-from object_library import all_couplings, Coupling
+from .object_library import all_couplings, Coupling
 
-from function_library import complexconjugate, re, im, csc, sec, acsc, asec, cot
+from .function_library import complexconjugate, re, im, csc, sec, acsc, asec, cot
 
 
 

--- a/UFO_models/SMEFTsim_topU3l_alphaScheme_UFO/__init__.py
+++ b/UFO_models/SMEFTsim_topU3l_alphaScheme_UFO/__init__.py
@@ -1,14 +1,13 @@
+from . import particles
+from . import couplings
+from . import lorentz
+from . import parameters
+from . import vertices
+from . import coupling_orders
+from . import write_param_card
+from . import propagators
 
-import particles
-import couplings
-import lorentz
-import parameters
-import vertices
-import coupling_orders
-import write_param_card
-import propagators
-
-import function_library
+from . import function_library
 
 
 all_particles = particles.all_particles
@@ -21,7 +20,7 @@ all_functions = function_library.all_functions
 all_propagators = propagators.all_propagators
 
 try:
-   import decays
+   from . import decays
 except ImportError:
    pass
 else:

--- a/UFO_models/SMEFTsim_topU3l_alphaScheme_UFO/coupling_orders.py
+++ b/UFO_models/SMEFTsim_topU3l_alphaScheme_UFO/coupling_orders.py
@@ -3,7 +3,7 @@
 # Date: Tue 18 Aug 2020 15:46:10
 
 
-from object_library import all_orders, CouplingOrder
+from .object_library import all_orders, CouplingOrder
 
 
 QCD = CouplingOrder(name = 'QCD',

--- a/UFO_models/SMEFTsim_topU3l_alphaScheme_UFO/couplings.py
+++ b/UFO_models/SMEFTsim_topU3l_alphaScheme_UFO/couplings.py
@@ -3,9 +3,9 @@
 # Date: Thu 7 Jan 2021 14:51:36
 
 
-from object_library import all_couplings, Coupling
+from .object_library import all_couplings, Coupling
 
-from function_library import complexconjugate, re, im, csc, sec, acsc, asec, cot
+from .function_library import complexconjugate, re, im, csc, sec, acsc, asec, cot
 
 
 

--- a/UFO_models/SMEFTsim_topU3l_alphaScheme_UFO/decays.py
+++ b/UFO_models/SMEFTsim_topU3l_alphaScheme_UFO/decays.py
@@ -3,8 +3,8 @@
 # Date: Thu 7 Jan 2021 14:51:37
 
 
-from object_library import all_decays, Decay
-import particles as P
+from .object_library import all_decays, Decay
+from . import particles as P
 
 
 Decay_b = Decay(name = 'Decay_b',

--- a/UFO_models/SMEFTsim_topU3l_alphaScheme_UFO/function_library.py
+++ b/UFO_models/SMEFTsim_topU3l_alphaScheme_UFO/function_library.py
@@ -12,7 +12,7 @@ __date__ = "22 July 2010"
 __author__ = "claude.duhr@durham.ac.uk"
 
 import cmath
-from object_library import all_functions, Function
+from .object_library import all_functions, Function
 
 #
 # shortcuts for functions from cmath

--- a/UFO_models/SMEFTsim_topU3l_alphaScheme_UFO/lorentz.py
+++ b/UFO_models/SMEFTsim_topU3l_alphaScheme_UFO/lorentz.py
@@ -3,9 +3,9 @@
 # Date: Thu 7 Jan 2021 14:51:36
 
 
-from object_library import all_lorentz, Lorentz
+from .object_library import all_lorentz, Lorentz
 
-from function_library import complexconjugate, re, im, csc, sec, acsc, asec, cot
+from .function_library import complexconjugate, re, im, csc, sec, acsc, asec, cot
 try:
    import form_factors as ForFac 
 except ImportError:

--- a/UFO_models/SMEFTsim_topU3l_alphaScheme_UFO/object_library.py
+++ b/UFO_models/SMEFTsim_topU3l_alphaScheme_UFO/object_library.py
@@ -14,7 +14,7 @@ class UFOError(Exception):
         """Exception raised if when inconsistencies are detected in the UFO model."""
         pass
 
-class UFOBaseClass(object):
+class UFOBaseClass:
     """The class from which all FeynRules classes are derived."""
 
     require_args = []
@@ -133,7 +133,7 @@ class Particle(UFOBaseClass):
         if self.selfconjugate:
             raise Exception('%s has no anti particle.' % self.name) 
         outdic = {}
-        for k,v in self.__dict__.iteritems():
+        for k,v in self.__dict__.items():
             if k not in self.require_args_all:                
                 outdic[k] = -v
         if self.color in [1,8]:
@@ -265,9 +265,9 @@ class Coupling(UFOBaseClass):
                if not CTparam:
                    CTparam=param
                else:
-                   raise UFOError, "UFO does not support yet more than one occurence of CTParameters in the couplings values."
+                   raise UFOError("UFO does not support yet more than one occurence of CTParameters in the couplings values.")
            elif numberOfMatches>1:
-               raise UFOError, "UFO does not support yet more than one occurence of CTParameters in the couplings values."
+               raise UFOError("UFO does not support yet more than one occurence of CTParameters in the couplings values.")
 
         if not CTparam:
             if x==0:
@@ -299,7 +299,7 @@ class Lorentz(UFOBaseClass):
 
 all_functions = []
 
-class Function(object):
+class Function:
 
     def __init__(self, name, arguments, expression):
 
@@ -313,13 +313,13 @@ class Function(object):
     def __call__(self, *opt):
 
         for i, arg in enumerate(self.arguments):
-            exec('%s = %s' % (arg, opt[i] ))
+            exec(f'{arg} = {opt[i]}')
 
         return eval(self.expr)
 
 all_orders = []
 
-class CouplingOrder(object):
+class CouplingOrder:
 
     def __init__(self, name, expansion_order, hierarchy, perturbative_expansion = 0):
         

--- a/UFO_models/SMEFTsim_topU3l_alphaScheme_UFO/parameters.py
+++ b/UFO_models/SMEFTsim_topU3l_alphaScheme_UFO/parameters.py
@@ -4,10 +4,10 @@
 
 
 
-from object_library import all_parameters, Parameter
+from .object_library import all_parameters, Parameter
 
 
-from function_library import complexconjugate, re, im, csc, sec, acsc, asec, cot
+from .function_library import complexconjugate, re, im, csc, sec, acsc, asec, cot
 
 # This is a default parameter object representing 0.
 ZERO = Parameter(name = 'ZERO',

--- a/UFO_models/SMEFTsim_topU3l_alphaScheme_UFO/particles.py
+++ b/UFO_models/SMEFTsim_topU3l_alphaScheme_UFO/particles.py
@@ -3,11 +3,11 @@
 # Date: Tue 7 Apr 2020 10:47:23
 
 
-from __future__ import division
-from object_library import all_particles, Particle
-import parameters as Param
 
-import propagators as Prop
+from .object_library import all_particles, Particle
+from . import parameters as Param
+
+from . import propagators as Prop
 
 a = Particle(pdg_code = 22,
              name = 'a',

--- a/UFO_models/SMEFTsim_topU3l_alphaScheme_UFO/propagators.py
+++ b/UFO_models/SMEFTsim_topU3l_alphaScheme_UFO/propagators.py
@@ -2,7 +2,7 @@
 # Mathematica version: 8.0 for Mac OS X x86 (64-bit) (November 6, 2010)
 # Date: Mon 1 Oct 2012 14:58:26
 
-from object_library import all_propagators, Propagator
+from .object_library import all_propagators, Propagator
 
 
 # define only once the denominator since this is always the same

--- a/UFO_models/SMEFTsim_topU3l_alphaScheme_UFO/vertices.py
+++ b/UFO_models/SMEFTsim_topU3l_alphaScheme_UFO/vertices.py
@@ -3,10 +3,10 @@
 # Date: Thu 7 Jan 2021 14:51:35
 
 
-from object_library import all_vertices, Vertex
-import particles as P
-import couplings as C
-import lorentz as L
+from .object_library import all_vertices, Vertex
+from . import particles as P
+from . import couplings as C
+from . import lorentz as L
 
 
 V_1 = Vertex(name = 'V_1',

--- a/UFO_models/SMEFTsim_topU3l_alphaScheme_UFO/write_param_card.py
+++ b/UFO_models/SMEFTsim_topU3l_alphaScheme_UFO/write_param_card.py
@@ -1,10 +1,9 @@
-
 __date__ = "02 Aug 2012"
 __author__ = 'olivier.mattelaer@uclouvain.be'
 
-from function_library import *
+from .function_library import *
 
-class ParamCardWriter(object):
+class ParamCardWriter:
     
     header = \
     """######################################################################\n""" + \
@@ -15,7 +14,7 @@ class ParamCardWriter(object):
         """write a valid param_card.dat"""
         
         if not list_of_parameters:
-            from parameters import all_parameters
+            from .parameters import all_parameters
             list_of_parameters = [param for param in all_parameters if \
                                                        param.nature=='external']
         
@@ -33,7 +32,7 @@ class ParamCardWriter(object):
     def define_not_dep_param(self, list_of_parameters):
         """define self.dep_mass and self.dep_width in case that they are 
         requested in the param_card.dat"""
-        from particles import all_particles
+        from .particles import all_particles
         
         self.dep_mass = [(part, part.mass) for part in all_particles \
                             if part.pdg_code > 0 and \
@@ -67,7 +66,7 @@ class ParamCardWriter(object):
         """ """
         
         # list all lhablock
-        all_lhablock = set([param.lhablock for param in all_ext_param])
+        all_lhablock = {param.lhablock for param in all_ext_param}
         
         # ordonate lhablock alphabeticaly
         all_lhablock = list(all_lhablock)
@@ -108,9 +107,9 @@ class ParamCardWriter(object):
         
         lhacode=' '.join(['%3s' % key for key in param.lhacode])
         if lhablock != 'DECAY':
-            text = """  %s %e # %s \n""" % (lhacode, complex(param.value).real, param.name ) 
+            text = f"""  {lhacode} {complex(param.value).real:e} # {param.name} \n""" 
         else:
-            text = '''DECAY %s %e \n''' % (lhacode, complex(param.value).real)
+            text = f'''DECAY {lhacode} {complex(param.value).real:e} \n'''
         self.fsock.write(text) 
                     
 
@@ -118,10 +117,10 @@ class ParamCardWriter(object):
     
     def write_dep_param_block(self, lhablock):
         import cmath
-        from parameters import all_parameters
-        from particles import all_particles
+        from .parameters import all_parameters
+        from .particles import all_particles
         for parameter in all_parameters:
-            exec("%s = %s" % (parameter.name, parameter.value))
+            exec(f"{parameter.name} = {parameter.value}")
         text = "##  Not dependent paramater.\n"
         text += "## Those values should be edited following analytical the \n"
         text += "## analytical expression. Some generator could simply ignore \n"
@@ -177,9 +176,9 @@ class ParamCardWriter(object):
     
     def write_qnumber(self):
         """ write qnumber """
-        from particles import all_particles
-        import particles
-        print particles.__file__
+        from .particles import all_particles
+        from . import particles
+        print(particles.__file__)
         text="""#===========================================================\n"""
         text += """# QUANTUM NUMBERS OF NEW STATE(S) (NON SM PDG CODE)\n"""
         text += """#===========================================================\n\n"""
@@ -204,5 +203,5 @@ class ParamCardWriter(object):
             
 if '__main__' == __name__:
     ParamCardWriter('./param_card.dat', generic=True)
-    print 'write ./param_card.dat'
+    print('write ./param_card.dat')
     

--- a/UFO_models/SMEFTsim_top_MwScheme_UFO/CT_couplings.py
+++ b/UFO_models/SMEFTsim_top_MwScheme_UFO/CT_couplings.py
@@ -3,9 +3,9 @@
 # Date: Mon 24 Aug 2020 00:42:31
 
 
-from object_library import all_couplings, Coupling
+from .object_library import all_couplings, Coupling
 
-from function_library import complexconjugate, re, im, csc, sec, acsc, asec, cot
+from .function_library import complexconjugate, re, im, csc, sec, acsc, asec, cot
 
 
 

--- a/UFO_models/SMEFTsim_top_MwScheme_UFO/__init__.py
+++ b/UFO_models/SMEFTsim_top_MwScheme_UFO/__init__.py
@@ -1,14 +1,13 @@
+from . import particles
+from . import couplings
+from . import lorentz
+from . import parameters
+from . import vertices
+from . import coupling_orders
+from . import write_param_card
+from . import propagators
 
-import particles
-import couplings
-import lorentz
-import parameters
-import vertices
-import coupling_orders
-import write_param_card
-import propagators
-
-import function_library
+from . import function_library
 
 
 all_particles = particles.all_particles
@@ -21,7 +20,7 @@ all_functions = function_library.all_functions
 all_propagators = propagators.all_propagators
 
 try:
-   import decays
+   from . import decays
 except ImportError:
    pass
 else:

--- a/UFO_models/SMEFTsim_top_MwScheme_UFO/coupling_orders.py
+++ b/UFO_models/SMEFTsim_top_MwScheme_UFO/coupling_orders.py
@@ -3,7 +3,7 @@
 # Date: Mon 24 Aug 2020 00:42:31
 
 
-from object_library import all_orders, CouplingOrder
+from .object_library import all_orders, CouplingOrder
 
 
 QCD = CouplingOrder(name = 'QCD',

--- a/UFO_models/SMEFTsim_top_MwScheme_UFO/couplings.py
+++ b/UFO_models/SMEFTsim_top_MwScheme_UFO/couplings.py
@@ -3,9 +3,9 @@
 # Date: Fri 8 Jan 2021 10:13:05
 
 
-from object_library import all_couplings, Coupling
+from .object_library import all_couplings, Coupling
 
-from function_library import complexconjugate, re, im, csc, sec, acsc, asec, cot
+from .function_library import complexconjugate, re, im, csc, sec, acsc, asec, cot
 
 
 

--- a/UFO_models/SMEFTsim_top_MwScheme_UFO/decays.py
+++ b/UFO_models/SMEFTsim_top_MwScheme_UFO/decays.py
@@ -3,8 +3,8 @@
 # Date: Fri 8 Jan 2021 10:13:06
 
 
-from object_library import all_decays, Decay
-import particles as P
+from .object_library import all_decays, Decay
+from . import particles as P
 
 
 Decay_b = Decay(name = 'Decay_b',

--- a/UFO_models/SMEFTsim_top_MwScheme_UFO/function_library.py
+++ b/UFO_models/SMEFTsim_top_MwScheme_UFO/function_library.py
@@ -12,7 +12,7 @@ __date__ = "22 July 2010"
 __author__ = "claude.duhr@durham.ac.uk"
 
 import cmath
-from object_library import all_functions, Function
+from .object_library import all_functions, Function
 
 #
 # shortcuts for functions from cmath

--- a/UFO_models/SMEFTsim_top_MwScheme_UFO/lorentz.py
+++ b/UFO_models/SMEFTsim_top_MwScheme_UFO/lorentz.py
@@ -3,9 +3,9 @@
 # Date: Fri 8 Jan 2021 10:13:04
 
 
-from object_library import all_lorentz, Lorentz
+from .object_library import all_lorentz, Lorentz
 
-from function_library import complexconjugate, re, im, csc, sec, acsc, asec, cot
+from .function_library import complexconjugate, re, im, csc, sec, acsc, asec, cot
 try:
    import form_factors as ForFac 
 except ImportError:

--- a/UFO_models/SMEFTsim_top_MwScheme_UFO/object_library.py
+++ b/UFO_models/SMEFTsim_top_MwScheme_UFO/object_library.py
@@ -14,7 +14,7 @@ class UFOError(Exception):
         """Exception raised if when inconsistencies are detected in the UFO model."""
         pass
 
-class UFOBaseClass(object):
+class UFOBaseClass:
     """The class from which all FeynRules classes are derived."""
 
     require_args = []
@@ -133,7 +133,7 @@ class Particle(UFOBaseClass):
         if self.selfconjugate:
             raise Exception('%s has no anti particle.' % self.name) 
         outdic = {}
-        for k,v in self.__dict__.iteritems():
+        for k,v in self.__dict__.items():
             if k not in self.require_args_all:                
                 outdic[k] = -v
         if self.color in [1,8]:
@@ -265,9 +265,9 @@ class Coupling(UFOBaseClass):
                if not CTparam:
                    CTparam=param
                else:
-                   raise UFOError, "UFO does not support yet more than one occurence of CTParameters in the couplings values."
+                   raise UFOError("UFO does not support yet more than one occurence of CTParameters in the couplings values.")
            elif numberOfMatches>1:
-               raise UFOError, "UFO does not support yet more than one occurence of CTParameters in the couplings values."
+               raise UFOError("UFO does not support yet more than one occurence of CTParameters in the couplings values.")
 
         if not CTparam:
             if x==0:
@@ -299,7 +299,7 @@ class Lorentz(UFOBaseClass):
 
 all_functions = []
 
-class Function(object):
+class Function:
 
     def __init__(self, name, arguments, expression):
 
@@ -313,13 +313,13 @@ class Function(object):
     def __call__(self, *opt):
 
         for i, arg in enumerate(self.arguments):
-            exec('%s = %s' % (arg, opt[i] ))
+            exec(f'{arg} = {opt[i]}')
 
         return eval(self.expr)
 
 all_orders = []
 
-class CouplingOrder(object):
+class CouplingOrder:
 
     def __init__(self, name, expansion_order, hierarchy, perturbative_expansion = 0):
         

--- a/UFO_models/SMEFTsim_top_MwScheme_UFO/parameters.py
+++ b/UFO_models/SMEFTsim_top_MwScheme_UFO/parameters.py
@@ -4,10 +4,10 @@
 
 
 
-from object_library import all_parameters, Parameter
+from .object_library import all_parameters, Parameter
 
 
-from function_library import complexconjugate, re, im, csc, sec, acsc, asec, cot
+from .function_library import complexconjugate, re, im, csc, sec, acsc, asec, cot
 
 # This is a default parameter object representing 0.
 ZERO = Parameter(name = 'ZERO',

--- a/UFO_models/SMEFTsim_top_MwScheme_UFO/particles.py
+++ b/UFO_models/SMEFTsim_top_MwScheme_UFO/particles.py
@@ -3,11 +3,11 @@
 # Date: Tue 7 Apr 2020 10:47:23
 
 
-from __future__ import division
-from object_library import all_particles, Particle
-import parameters as Param
 
-import propagators as Prop
+from .object_library import all_particles, Particle
+from . import parameters as Param
+
+from . import propagators as Prop
 
 a = Particle(pdg_code = 22,
              name = 'a',

--- a/UFO_models/SMEFTsim_top_MwScheme_UFO/propagators.py
+++ b/UFO_models/SMEFTsim_top_MwScheme_UFO/propagators.py
@@ -2,7 +2,7 @@
 # Mathematica version: 8.0 for Mac OS X x86 (64-bit) (November 6, 2010)
 # Date: Mon 1 Oct 2012 14:58:26
 
-from object_library import all_propagators, Propagator
+from .object_library import all_propagators, Propagator
 
 
 # define only once the denominator since this is always the same

--- a/UFO_models/SMEFTsim_top_MwScheme_UFO/vertices.py
+++ b/UFO_models/SMEFTsim_top_MwScheme_UFO/vertices.py
@@ -3,10 +3,10 @@
 # Date: Fri 8 Jan 2021 10:13:04
 
 
-from object_library import all_vertices, Vertex
-import particles as P
-import couplings as C
-import lorentz as L
+from .object_library import all_vertices, Vertex
+from . import particles as P
+from . import couplings as C
+from . import lorentz as L
 
 
 V_1 = Vertex(name = 'V_1',

--- a/UFO_models/SMEFTsim_top_MwScheme_UFO/write_param_card.py
+++ b/UFO_models/SMEFTsim_top_MwScheme_UFO/write_param_card.py
@@ -1,10 +1,9 @@
-
 __date__ = "02 Aug 2012"
 __author__ = 'olivier.mattelaer@uclouvain.be'
 
-from function_library import *
+from .function_library import *
 
-class ParamCardWriter(object):
+class ParamCardWriter:
     
     header = \
     """######################################################################\n""" + \
@@ -15,7 +14,7 @@ class ParamCardWriter(object):
         """write a valid param_card.dat"""
         
         if not list_of_parameters:
-            from parameters import all_parameters
+            from .parameters import all_parameters
             list_of_parameters = [param for param in all_parameters if \
                                                        param.nature=='external']
         
@@ -33,7 +32,7 @@ class ParamCardWriter(object):
     def define_not_dep_param(self, list_of_parameters):
         """define self.dep_mass and self.dep_width in case that they are 
         requested in the param_card.dat"""
-        from particles import all_particles
+        from .particles import all_particles
         
         self.dep_mass = [(part, part.mass) for part in all_particles \
                             if part.pdg_code > 0 and \
@@ -67,7 +66,7 @@ class ParamCardWriter(object):
         """ """
         
         # list all lhablock
-        all_lhablock = set([param.lhablock for param in all_ext_param])
+        all_lhablock = {param.lhablock for param in all_ext_param}
         
         # ordonate lhablock alphabeticaly
         all_lhablock = list(all_lhablock)
@@ -108,9 +107,9 @@ class ParamCardWriter(object):
         
         lhacode=' '.join(['%3s' % key for key in param.lhacode])
         if lhablock != 'DECAY':
-            text = """  %s %e # %s \n""" % (lhacode, complex(param.value).real, param.name ) 
+            text = f"""  {lhacode} {complex(param.value).real:e} # {param.name} \n""" 
         else:
-            text = '''DECAY %s %e \n''' % (lhacode, complex(param.value).real)
+            text = f'''DECAY {lhacode} {complex(param.value).real:e} \n'''
         self.fsock.write(text) 
                     
 
@@ -118,10 +117,10 @@ class ParamCardWriter(object):
     
     def write_dep_param_block(self, lhablock):
         import cmath
-        from parameters import all_parameters
-        from particles import all_particles
+        from .parameters import all_parameters
+        from .particles import all_particles
         for parameter in all_parameters:
-            exec("%s = %s" % (parameter.name, parameter.value))
+            exec(f"{parameter.name} = {parameter.value}")
         text = "##  Not dependent paramater.\n"
         text += "## Those values should be edited following analytical the \n"
         text += "## analytical expression. Some generator could simply ignore \n"
@@ -177,9 +176,9 @@ class ParamCardWriter(object):
     
     def write_qnumber(self):
         """ write qnumber """
-        from particles import all_particles
-        import particles
-        print particles.__file__
+        from .particles import all_particles
+        from . import particles
+        print(particles.__file__)
         text="""#===========================================================\n"""
         text += """# QUANTUM NUMBERS OF NEW STATE(S) (NON SM PDG CODE)\n"""
         text += """#===========================================================\n\n"""
@@ -204,5 +203,5 @@ class ParamCardWriter(object):
             
 if '__main__' == __name__:
     ParamCardWriter('./param_card.dat', generic=True)
-    print 'write ./param_card.dat'
+    print('write ./param_card.dat')
     

--- a/UFO_models/SMEFTsim_top_alphaScheme_UFO/CT_couplings.py
+++ b/UFO_models/SMEFTsim_top_alphaScheme_UFO/CT_couplings.py
@@ -3,9 +3,9 @@
 # Date: Tue 25 Aug 2020 10:10:56
 
 
-from object_library import all_couplings, Coupling
+from .object_library import all_couplings, Coupling
 
-from function_library import complexconjugate, re, im, csc, sec, acsc, asec, cot
+from .function_library import complexconjugate, re, im, csc, sec, acsc, asec, cot
 
 
 

--- a/UFO_models/SMEFTsim_top_alphaScheme_UFO/__init__.py
+++ b/UFO_models/SMEFTsim_top_alphaScheme_UFO/__init__.py
@@ -1,14 +1,13 @@
+from . import particles
+from . import couplings
+from . import lorentz
+from . import parameters
+from . import vertices
+from . import coupling_orders
+from . import write_param_card
+from . import propagators
 
-import particles
-import couplings
-import lorentz
-import parameters
-import vertices
-import coupling_orders
-import write_param_card
-import propagators
-
-import function_library
+from . import function_library
 
 
 all_particles = particles.all_particles
@@ -21,7 +20,7 @@ all_functions = function_library.all_functions
 all_propagators = propagators.all_propagators
 
 try:
-   import decays
+   from . import decays
 except ImportError:
    pass
 else:

--- a/UFO_models/SMEFTsim_top_alphaScheme_UFO/coupling_orders.py
+++ b/UFO_models/SMEFTsim_top_alphaScheme_UFO/coupling_orders.py
@@ -3,7 +3,7 @@
 # Date: Tue 25 Aug 2020 10:10:55
 
 
-from object_library import all_orders, CouplingOrder
+from .object_library import all_orders, CouplingOrder
 
 
 QCD = CouplingOrder(name = 'QCD',

--- a/UFO_models/SMEFTsim_top_alphaScheme_UFO/couplings.py
+++ b/UFO_models/SMEFTsim_top_alphaScheme_UFO/couplings.py
@@ -3,9 +3,9 @@
 # Date: Fri 8 Jan 2021 11:25:12
 
 
-from object_library import all_couplings, Coupling
+from .object_library import all_couplings, Coupling
 
-from function_library import complexconjugate, re, im, csc, sec, acsc, asec, cot
+from .function_library import complexconjugate, re, im, csc, sec, acsc, asec, cot
 
 
 

--- a/UFO_models/SMEFTsim_top_alphaScheme_UFO/decays.py
+++ b/UFO_models/SMEFTsim_top_alphaScheme_UFO/decays.py
@@ -3,8 +3,8 @@
 # Date: Fri 8 Jan 2021 11:25:14
 
 
-from object_library import all_decays, Decay
-import particles as P
+from .object_library import all_decays, Decay
+from . import particles as P
 
 
 Decay_b = Decay(name = 'Decay_b',

--- a/UFO_models/SMEFTsim_top_alphaScheme_UFO/function_library.py
+++ b/UFO_models/SMEFTsim_top_alphaScheme_UFO/function_library.py
@@ -12,7 +12,7 @@ __date__ = "22 July 2010"
 __author__ = "claude.duhr@durham.ac.uk"
 
 import cmath
-from object_library import all_functions, Function
+from .object_library import all_functions, Function
 
 #
 # shortcuts for functions from cmath

--- a/UFO_models/SMEFTsim_top_alphaScheme_UFO/lorentz.py
+++ b/UFO_models/SMEFTsim_top_alphaScheme_UFO/lorentz.py
@@ -3,9 +3,9 @@
 # Date: Fri 8 Jan 2021 11:25:11
 
 
-from object_library import all_lorentz, Lorentz
+from .object_library import all_lorentz, Lorentz
 
-from function_library import complexconjugate, re, im, csc, sec, acsc, asec, cot
+from .function_library import complexconjugate, re, im, csc, sec, acsc, asec, cot
 try:
    import form_factors as ForFac 
 except ImportError:

--- a/UFO_models/SMEFTsim_top_alphaScheme_UFO/object_library.py
+++ b/UFO_models/SMEFTsim_top_alphaScheme_UFO/object_library.py
@@ -14,7 +14,7 @@ class UFOError(Exception):
         """Exception raised if when inconsistencies are detected in the UFO model."""
         pass
 
-class UFOBaseClass(object):
+class UFOBaseClass:
     """The class from which all FeynRules classes are derived."""
 
     require_args = []
@@ -133,7 +133,7 @@ class Particle(UFOBaseClass):
         if self.selfconjugate:
             raise Exception('%s has no anti particle.' % self.name) 
         outdic = {}
-        for k,v in self.__dict__.iteritems():
+        for k,v in self.__dict__.items():
             if k not in self.require_args_all:                
                 outdic[k] = -v
         if self.color in [1,8]:
@@ -265,9 +265,9 @@ class Coupling(UFOBaseClass):
                if not CTparam:
                    CTparam=param
                else:
-                   raise UFOError, "UFO does not support yet more than one occurence of CTParameters in the couplings values."
+                   raise UFOError("UFO does not support yet more than one occurence of CTParameters in the couplings values.")
            elif numberOfMatches>1:
-               raise UFOError, "UFO does not support yet more than one occurence of CTParameters in the couplings values."
+               raise UFOError("UFO does not support yet more than one occurence of CTParameters in the couplings values.")
 
         if not CTparam:
             if x==0:
@@ -299,7 +299,7 @@ class Lorentz(UFOBaseClass):
 
 all_functions = []
 
-class Function(object):
+class Function:
 
     def __init__(self, name, arguments, expression):
 
@@ -313,13 +313,13 @@ class Function(object):
     def __call__(self, *opt):
 
         for i, arg in enumerate(self.arguments):
-            exec('%s = %s' % (arg, opt[i] ))
+            exec(f'{arg} = {opt[i]}')
 
         return eval(self.expr)
 
 all_orders = []
 
-class CouplingOrder(object):
+class CouplingOrder:
 
     def __init__(self, name, expansion_order, hierarchy, perturbative_expansion = 0):
         

--- a/UFO_models/SMEFTsim_top_alphaScheme_UFO/parameters.py
+++ b/UFO_models/SMEFTsim_top_alphaScheme_UFO/parameters.py
@@ -4,10 +4,10 @@
 
 
 
-from object_library import all_parameters, Parameter
+from .object_library import all_parameters, Parameter
 
 
-from function_library import complexconjugate, re, im, csc, sec, acsc, asec, cot
+from .function_library import complexconjugate, re, im, csc, sec, acsc, asec, cot
 
 # This is a default parameter object representing 0.
 ZERO = Parameter(name = 'ZERO',

--- a/UFO_models/SMEFTsim_top_alphaScheme_UFO/particles.py
+++ b/UFO_models/SMEFTsim_top_alphaScheme_UFO/particles.py
@@ -3,11 +3,11 @@
 # Date: Tue 7 Apr 2020 10:47:23
 
 
-from __future__ import division
-from object_library import all_particles, Particle
-import parameters as Param
 
-import propagators as Prop
+from .object_library import all_particles, Particle
+from . import parameters as Param
+
+from . import propagators as Prop
 
 a = Particle(pdg_code = 22,
              name = 'a',

--- a/UFO_models/SMEFTsim_top_alphaScheme_UFO/propagators.py
+++ b/UFO_models/SMEFTsim_top_alphaScheme_UFO/propagators.py
@@ -2,7 +2,7 @@
 # Mathematica version: 8.0 for Mac OS X x86 (64-bit) (November 6, 2010)
 # Date: Mon 1 Oct 2012 14:58:26
 
-from object_library import all_propagators, Propagator
+from .object_library import all_propagators, Propagator
 
 
 # define only once the denominator since this is always the same

--- a/UFO_models/SMEFTsim_top_alphaScheme_UFO/vertices.py
+++ b/UFO_models/SMEFTsim_top_alphaScheme_UFO/vertices.py
@@ -3,10 +3,10 @@
 # Date: Fri 8 Jan 2021 11:25:11
 
 
-from object_library import all_vertices, Vertex
-import particles as P
-import couplings as C
-import lorentz as L
+from .object_library import all_vertices, Vertex
+from . import particles as P
+from . import couplings as C
+from . import lorentz as L
 
 
 V_1 = Vertex(name = 'V_1',

--- a/UFO_models/SMEFTsim_top_alphaScheme_UFO/write_param_card.py
+++ b/UFO_models/SMEFTsim_top_alphaScheme_UFO/write_param_card.py
@@ -1,10 +1,9 @@
-
 __date__ = "02 Aug 2012"
 __author__ = 'olivier.mattelaer@uclouvain.be'
 
-from function_library import *
+from .function_library import *
 
-class ParamCardWriter(object):
+class ParamCardWriter:
     
     header = \
     """######################################################################\n""" + \
@@ -15,7 +14,7 @@ class ParamCardWriter(object):
         """write a valid param_card.dat"""
         
         if not list_of_parameters:
-            from parameters import all_parameters
+            from .parameters import all_parameters
             list_of_parameters = [param for param in all_parameters if \
                                                        param.nature=='external']
         
@@ -33,7 +32,7 @@ class ParamCardWriter(object):
     def define_not_dep_param(self, list_of_parameters):
         """define self.dep_mass and self.dep_width in case that they are 
         requested in the param_card.dat"""
-        from particles import all_particles
+        from .particles import all_particles
         
         self.dep_mass = [(part, part.mass) for part in all_particles \
                             if part.pdg_code > 0 and \
@@ -67,7 +66,7 @@ class ParamCardWriter(object):
         """ """
         
         # list all lhablock
-        all_lhablock = set([param.lhablock for param in all_ext_param])
+        all_lhablock = {param.lhablock for param in all_ext_param}
         
         # ordonate lhablock alphabeticaly
         all_lhablock = list(all_lhablock)
@@ -108,9 +107,9 @@ class ParamCardWriter(object):
         
         lhacode=' '.join(['%3s' % key for key in param.lhacode])
         if lhablock != 'DECAY':
-            text = """  %s %e # %s \n""" % (lhacode, complex(param.value).real, param.name ) 
+            text = f"""  {lhacode} {complex(param.value).real:e} # {param.name} \n""" 
         else:
-            text = '''DECAY %s %e \n''' % (lhacode, complex(param.value).real)
+            text = f'''DECAY {lhacode} {complex(param.value).real:e} \n'''
         self.fsock.write(text) 
                     
 
@@ -118,10 +117,10 @@ class ParamCardWriter(object):
     
     def write_dep_param_block(self, lhablock):
         import cmath
-        from parameters import all_parameters
-        from particles import all_particles
+        from .parameters import all_parameters
+        from .particles import all_particles
         for parameter in all_parameters:
-            exec("%s = %s" % (parameter.name, parameter.value))
+            exec(f"{parameter.name} = {parameter.value}")
         text = "##  Not dependent paramater.\n"
         text += "## Those values should be edited following analytical the \n"
         text += "## analytical expression. Some generator could simply ignore \n"
@@ -177,9 +176,9 @@ class ParamCardWriter(object):
     
     def write_qnumber(self):
         """ write qnumber """
-        from particles import all_particles
-        import particles
-        print particles.__file__
+        from .particles import all_particles
+        from . import particles
+        print(particles.__file__)
         text="""#===========================================================\n"""
         text += """# QUANTUM NUMBERS OF NEW STATE(S) (NON SM PDG CODE)\n"""
         text += """#===========================================================\n\n"""
@@ -204,5 +203,5 @@ class ParamCardWriter(object):
             
 if '__main__' == __name__:
     ParamCardWriter('./param_card.dat', generic=True)
-    print 'write ./param_card.dat'
+    print('write ./param_card.dat')
     


### PR DESCRIPTION
Resolves #4

As FeynRules `v2.3.35` produces Python 2 code only and modern MadGraph5_aMC@NLO is Python 3 based (and is [dropping support for Python 2 in December 2021](https://launchpad.net/mg5amcnlo/+announcement/22860)) manually migrate all UFO models to Python 3.6+ by using the [`2to3`](https://docs.python.org/3/library/2to3.html) utility and [`pyupgrade`](https://github.com/asottile/pyupgrade) with the `--py36-plus` option.

The effects of this commit were carried out by:

* Running `2to3` in place on the codebase:

```console
$ 2to3 --write .
```

* Manually undoing the effects of 2to3's use of list(dict.keys()) and list(dict.items()) to reduce the amount of unnecessary diffs. dict.keys() and dict.items() are iterables, and in the manner they are used in the UFO model code it is as iterables and not as lists.

* Running pyupgrade with the --py36-plus option. For ease of use this was run as a pre-commit hook, but the effects are equivalent to running the following

```console
$ find -name '*.py' -print | xargs pyupgrade --py36-plus
```

This PR contains 130 files worth of diffs, but it should be easier to review then it sounds as the changes were programmatically applied and the UFO models all follow the same structure. So if one module is reviewed this should be the equivalent to reviewing all modules.

---

Replicating the example shown in Issue #4 to show things working now:

```console
$ docker run --rm -ti scailfin/madgraph5-amc-nlo:mg5_amc3.3.0
root@86f5c214b968:~/data# git clone --depth 1 https://github.com/matthewfeickert/SMEFTsim.git --branch fix/python3-migration --single-branch /tmp/SMEFTsim
Cloning into '/tmp/SMEFTsim'...
remote: Enumerating objects: 141, done.
remote: Counting objects: 100% (141/141), done.
remote: Compressing objects: 100% (55/55), done.
remote: Total 141 (delta 104), reused 106 (delta 85), pack-reused 0
Receiving objects: 100% (141/141), 3.45 MiB | 9.14 MiB/s, done.
Resolving deltas: 100% (104/104), done.
root@86f5c214b968:~/data# cp -r /tmp/SMEFTsim/UFO_models/* $(dirname $(command -v mg5_aMC))/../models
root@86f5c214b968:~/data# echo "import model SMEFTsim_U35_MwScheme_UFO" | mg5_aMC
************************************************************
*                                                          *
*                     W E L C O M E to                     *
*              M A D G R A P H 5 _ a M C @ N L O           *
*                                                          *
*                                                          *
*                 *                       *                *
*                   *        * *        *                  *
*                     * * * * 5 * * * *                    *
*                   *        * *        *                  *
*                 *                       *                *
*                                                          *
*         VERSION 3.3.0                 2021-11-12         *
*                                                          *
*    The MadGraph5_aMC@NLO Development Team - Find us at   *
*    https://server06.fynu.ucl.ac.be/projects/madgraph     *
*                            and                           *
*            http://amcatnlo.web.cern.ch/amcatnlo/         *
*                                                          *
*               Type 'help' for in-line help.              *
*           Type 'tutorial' to learn how MG5 works         *
*    Type 'tutorial aMCatNLO' to learn how aMC@NLO works   *
*    Type 'tutorial MadLoop' to learn how MadLoop works    *
*                                                          *
************************************************************
load MG5 configuration from ../../usr/local/venv/MG5_aMC/input/mg5_configuration.txt 
set fastjet to fastjet-config
set ninja to /usr/local/venv/MG5_aMC/HEPTools/lib
set collier to /usr/local/venv/MG5_aMC/HEPTools/lib
set lhapdf to lhapdf-config
set lhapdf to lhapdf-config
Using default text editor "vi". Set another one in ./input/mg5_configuration.txt
No valid web browser found. Please set in ./input/mg5_configuration.txt
Loading default model: sm
INFO: Restrict model sm with file ../../usr/local/venv/MG5_aMC/models/sm/restrict_default.dat . 
INFO: Run "set stdout_level DEBUG" before import for more information. 
INFO: Change particles name to pass to MG5 convention 
Defined multiparticle p = g u c d s u~ c~ d~ s~
Defined multiparticle j = g u c d s u~ c~ d~ s~
Defined multiparticle l+ = e+ mu+
Defined multiparticle l- = e- mu-
Defined multiparticle vl = ve vm vt
Defined multiparticle vl~ = ve~ vm~ vt~
Defined multiparticle all = g u c d s u~ c~ d~ s~ a ve vm vt e- mu- ve~ vm~ vt~ e+ mu+ t b t~ b~ z w+ h w- ta- ta+
MG5_aMC>INFO: load particles 
INFO: load vertices 
CRITICAL: Model with non QCD emission of gluon (found 14 of those).
  This type of model is not fully supported within MG5aMC.
  Restriction on LO dynamical scale and MLM matching/merging can occur for some processes.
  Use such features with care. 
INFO: Change particles name to pass to MG5 convention 
Kept definitions of multiparticles p / j / l+ / l- / vl / vl~ unchanged
Defined multiparticle all = g a ve vm vt ve~ vm~ vt~ u c t d s b t1 u~ c~ t~ d~ s~ b~ t1~ z w+ z1 w1+ h h1 w- w1- e- mu- ta- e+ mu+ ta+
MG5_aMC>root@86f5c214b968:~/data# 
```

---

Note that this PR is meant to be a stopgap as the better solution is to be able to convince the FeynRules maintainers to upgrade to support Python 3.