### PR TITLE
add NP tags

### DIFF
--- a/UFO_models/SMEFTsim_top_MwScheme_UFO/coupling_orders.py
+++ b/UFO_models/SMEFTsim_top_MwScheme_UFO/coupling_orders.py
@@ -178,6 +178,18 @@ NPcHe = CouplingOrder(name = 'NPcHe',
                       expansion_order = 99,
                       hierarchy = 1)
 
+NPcHe11 = CouplingOrder(name = 'NPcHe11',
+                        expansion_order = 99,
+                        hierarchy = 1)
+
+NPcHe22 = CouplingOrder(name = 'NPcHe22',
+                        expansion_order = 99,
+                        hierarchy = 1)
+
+NPcHe33 = CouplingOrder(name = 'NPcHe33',
+                        expansion_order = 99,
+                        hierarchy = 1)
+
 NPcHG = CouplingOrder(name = 'NPcHG',
                       expansion_order = 99,
                       hierarchy = 1)
@@ -198,9 +210,33 @@ NPcHl1 = CouplingOrder(name = 'NPcHl1',
                        expansion_order = 99,
                        hierarchy = 1)
 
+NPcHl111 = CouplingOrder(name = 'NPcHl111',
+                         expansion_order = 99,
+                         hierarchy = 1)
+
+NPcHl122 = CouplingOrder(name = 'NPcHl122',
+                         expansion_order = 99,
+                         hierarchy = 1)
+
+NPcHl133 = CouplingOrder(name = 'NPcHl133',
+                         expansion_order = 99,
+                         hierarchy = 1)
+
 NPcHl3 = CouplingOrder(name = 'NPcHl3',
                        expansion_order = 99,
                        hierarchy = 1)
+
+NPcHl311 = CouplingOrder(name = 'NPcHl311',
+                         expansion_order = 99,
+                         hierarchy = 1)
+
+NPcHl322 = CouplingOrder(name = 'NPcHl322',
+                         expansion_order = 99,
+                         hierarchy = 1)
+
+NPcHl333 = CouplingOrder(name = 'NPcHl333',
+                         expansion_order = 99,
+                         hierarchy = 1)
 
 NPcHQ1 = CouplingOrder(name = 'NPcHQ1',
                        expansion_order = 99,
@@ -377,6 +413,42 @@ NPcll = CouplingOrder(name = 'NPcll',
 NPcll1 = CouplingOrder(name = 'NPcll1',
                        expansion_order = 99,
                        hierarchy = 1)
+
+NPcll1111 = CouplingOrder(name = 'NPcll1111',
+                          expansion_order = 99,
+                          hierarchy = 1)
+
+NPcll2222 = CouplingOrder(name = 'NPcll2222',
+                          expansion_order = 99,
+                          hierarchy = 1)
+
+NPcll3333 = CouplingOrder(name = 'NPcll3333',
+                          expansion_order = 99,
+                          hierarchy = 1)
+
+NPcll1122 = CouplingOrder(name = 'NPcll1122',
+                          expansion_order = 99,
+                          hierarchy = 1)
+
+NPcll1133 = CouplingOrder(name = 'NPcll1133',
+                          expansion_order = 99,
+                          hierarchy = 1)
+
+NPcll2233 = CouplingOrder(name = 'NPcll2233',
+                          expansion_order = 99,
+                          hierarchy = 1)
+
+NPcll1221 = CouplingOrder(name = 'NPcll1221',
+                          expansion_order = 99,
+                          hierarchy = 1)
+
+NPcll1331 = CouplingOrder(name = 'NPcll1331',
+                          expansion_order = 99,
+                          hierarchy = 1)
+
+NPcll2332 = CouplingOrder(name = 'NPcll2332',
+                          expansion_order = 99,
+                          hierarchy = 1)
 
 NPclu = CouplingOrder(name = 'NPclu',
                       expansion_order = 99,

--- a/UFO_models/SMEFTsim_top_MwScheme_UFO/couplings.py
+++ b/UFO_models/SMEFTsim_top_MwScheme_UFO/couplings.py
@@ -627,39 +627,39 @@ GC_154 = Coupling(name = 'GC_154',
 
 GC_155 = Coupling(name = 'GC_155',
                   value = '(2*cll1111*complex(0,1))/LambdaSMEFT**2',
-                  order = {'NP':1,'NPcll':1,'QED':2})
+                  order = {'NP':1,'NPcll':1,'QED':2,'NPcll1111':1})
 
 GC_156 = Coupling(name = 'GC_156',
                   value = '(cll1122*complex(0,1))/LambdaSMEFT**2',
-                  order = {'NP':1,'NPcll':1,'QED':2})
+                  order = {'NP':1,'NPcll':1,'QED':2,'NPcll1122':1})
 
 GC_157 = Coupling(name = 'GC_157',
                   value = '(cll1133*complex(0,1))/LambdaSMEFT**2',
-                  order = {'NP':1,'NPcll':1,'QED':2})
+                  order = {'NP':1,'NPcll':1,'QED':2,'NPcll1133':1})
 
 GC_158 = Coupling(name = 'GC_158',
                   value = '(cll1221*complex(0,1))/LambdaSMEFT**2',
-                  order = {'NP':1,'NPcll1':1,'QED':2})
+                  order = {'NP':1,'NPcll1':1,'QED':2,'NPcll1221':1})
 
 GC_159 = Coupling(name = 'GC_159',
                   value = '(cll1331*complex(0,1))/LambdaSMEFT**2',
-                  order = {'NP':1,'NPcll1':1,'QED':2})
+                  order = {'NP':1,'NPcll1':1,'QED':2,'NPcll1331':1})
 
 GC_160 = Coupling(name = 'GC_160',
                   value = '(2*cll2222*complex(0,1))/LambdaSMEFT**2',
-                  order = {'NP':1,'NPcll':1,'QED':2})
+                  order = {'NP':1,'NPcll':1,'QED':2,'NPcll2222':1})
 
 GC_161 = Coupling(name = 'GC_161',
                   value = '(cll2233*complex(0,1))/LambdaSMEFT**2',
-                  order = {'NP':1,'NPcll':1,'QED':2})
+                  order = {'NP':1,'NPcll':1,'QED':2,'NPcll2233':1})
 
 GC_162 = Coupling(name = 'GC_162',
                   value = '(cll2332*complex(0,1))/LambdaSMEFT**2',
-                  order = {'NP':1,'NPcll1':1,'QED':2})
+                  order = {'NP':1,'NPcll1':1,'QED':2,'NPcll2332':1})
 
 GC_163 = Coupling(name = 'GC_163',
                   value = '(2*cll3333*complex(0,1))/LambdaSMEFT**2',
-                  order = {'NP':1,'NPcll':1,'QED':2})
+                  order = {'NP':1,'NPcll':1,'QED':2,'NPcll3333':1})
 
 GC_164 = Coupling(name = 'GC_164',
                   value = '(clu11*complex(0,1))/LambdaSMEFT**2',
@@ -1467,15 +1467,15 @@ GC_364 = Coupling(name = 'GC_364',
 
 GC_365 = Coupling(name = 'GC_365',
                   value = '(cHe11*ee*complex(0,1))/(cth*LambdaSMEFT**2*sth)',
-                  order = {'NP':1,'NPcHe':1,'QED':3})
+                  order = {'NP':1,'NPcHe':1,'QED':3,'NPcHe11':1})
 
 GC_366 = Coupling(name = 'GC_366',
                   value = '(cHe22*ee*complex(0,1))/(cth*LambdaSMEFT**2*sth)',
-                  order = {'NP':1,'NPcHe':1,'QED':3})
+                  order = {'NP':1,'NPcHe':1,'QED':3,'NPcHe22':1})
 
 GC_367 = Coupling(name = 'GC_367',
                   value = '(cHe33*ee*complex(0,1))/(cth*LambdaSMEFT**2*sth)',
-                  order = {'NP':1,'NPcHe':1,'QED':3})
+                  order = {'NP':1,'NPcHe':1,'QED':3,'NPcHe33':1})
 
 GC_368 = Coupling(name = 'GC_368',
                   value = '(cHj1*ee*complex(0,1))/(cth*LambdaSMEFT**2*sth)',
@@ -1491,15 +1491,15 @@ GC_370 = Coupling(name = 'GC_370',
 
 GC_371 = Coupling(name = 'GC_371',
                   value = '(cHl111*ee*complex(0,1))/(cth*LambdaSMEFT**2*sth)',
-                  order = {'NP':1,'NPcHl1':1,'QED':3})
+                  order = {'NP':1,'NPcHl1':1,'QED':3,'NPcHl111':1})
 
 GC_372 = Coupling(name = 'GC_372',
                   value = '(cHl122*ee*complex(0,1))/(cth*LambdaSMEFT**2*sth)',
-                  order = {'NP':1,'NPcHl1':1,'QED':3})
+                  order = {'NP':1,'NPcHl1':1,'QED':3,'NPcHl122':1})
 
 GC_373 = Coupling(name = 'GC_373',
                   value = '(cHl133*ee*complex(0,1))/(cth*LambdaSMEFT**2*sth)',
-                  order = {'NP':1,'NPcHl1':1,'QED':3})
+                  order = {'NP':1,'NPcHl1':1,'QED':3,'NPcHl133':1})
 
 GC_374 = Coupling(name = 'GC_374',
                   value = '-((cHl311*ee*complex(0,1))/(cth*LambdaSMEFT**2*sth))',
@@ -2539,15 +2539,15 @@ GC_632 = Coupling(name = 'GC_632',
 
 GC_633 = Coupling(name = 'GC_633',
                   value = '(cHe11*ee*complex(0,1)*vevhat)/(cth*LambdaSMEFT**2*sth)',
-                  order = {'NP':1,'NPcHe':1,'QED':2})
+                  order = {'NP':1,'NPcHe':1,'QED':2,'NPcHe11':1})
 
 GC_634 = Coupling(name = 'GC_634',
                   value = '(cHe22*ee*complex(0,1)*vevhat)/(cth*LambdaSMEFT**2*sth)',
-                  order = {'NP':1,'NPcHe':1,'QED':2})
+                  order = {'NP':1,'NPcHe':1,'QED':2,'NPcHe22':1})
 
 GC_635 = Coupling(name = 'GC_635',
                   value = '(cHe33*ee*complex(0,1)*vevhat)/(cth*LambdaSMEFT**2*sth)',
-                  order = {'NP':1,'NPcHe':1,'QED':2})
+                  order = {'NP':1,'NPcHe':1,'QED':2,'NPcHe33':1})
 
 GC_636 = Coupling(name = 'GC_636',
                   value = '(cHj1*ee*complex(0,1)*vevhat)/(cth*LambdaSMEFT**2*sth)',
@@ -2563,15 +2563,15 @@ GC_638 = Coupling(name = 'GC_638',
 
 GC_639 = Coupling(name = 'GC_639',
                   value = '(cHl111*ee*complex(0,1)*vevhat)/(cth*LambdaSMEFT**2*sth)',
-                  order = {'NP':1,'NPcHl1':1,'QED':2})
+                  order = {'NP':1,'NPcHl1':1,'QED':2,'NPcHl111':1})
 
 GC_640 = Coupling(name = 'GC_640',
                   value = '(cHl122*ee*complex(0,1)*vevhat)/(cth*LambdaSMEFT**2*sth)',
-                  order = {'NP':1,'NPcHl1':1,'QED':2})
+                  order = {'NP':1,'NPcHl1':1,'QED':2,'NPcHl122':1})
 
 GC_641 = Coupling(name = 'GC_641',
                   value = '(cHl133*ee*complex(0,1)*vevhat)/(cth*LambdaSMEFT**2*sth)',
-                  order = {'NP':1,'NPcHl1':1,'QED':2})
+                  order = {'NP':1,'NPcHl1':1,'QED':2,'NPcHl133':1})
 
 GC_642 = Coupling(name = 'GC_642',
                   value = '-((cHl311*ee*complex(0,1)*vevhat)/(cth*LambdaSMEFT**2*sth))',
@@ -2903,23 +2903,23 @@ GC_723 = Coupling(name = 'GC_723',
 
 GC_724 = Coupling(name = 'GC_724',
                   value = '(cll1221*ee*complex(0,1)*vevhat**2)/(12.*LambdaSMEFT**2)',
-                  order = {'NP':1,'NPcll1':1,'QED':1})
+                  order = {'NP':1,'NPcll1':1,'QED':1,'NPcll1221':1})
 
 GC_725 = Coupling(name = 'GC_725',
                   value = '-(cll1221*ee*complex(0,1)*vevhat**2)/(6.*LambdaSMEFT**2)',
-                  order = {'NP':1,'NPcll1':1,'QED':1})
+                  order = {'NP':1,'NPcll1':1,'QED':1,'NPcll1221':1})
 
 GC_726 = Coupling(name = 'GC_726',
                   value = '-(cll1221*ee*complex(0,1)*vevhat**2)/(4.*LambdaSMEFT**2)',
-                  order = {'NP':1,'NPcll1':1,'QED':1})
+                  order = {'NP':1,'NPcll1':1,'QED':1,'NPcll1221':1})
 
 GC_727 = Coupling(name = 'GC_727',
                   value = '(cll1221*ee*complex(0,1)*vevhat**2)/(4.*LambdaSMEFT**2)',
-                  order = {'NP':1,'NPcll1':1,'QED':1})
+                  order = {'NP':1,'NPcll1':1,'QED':1,'NPcll1221':1})
 
 GC_728 = Coupling(name = 'GC_728',
                   value = '(cll1221*ee**2*complex(0,1)*vevhat**2)/(2.*LambdaSMEFT**2)',
-                  order = {'NP':1,'NPcll1':1,'QED':2})
+                  order = {'NP':1,'NPcll1':1,'QED':2,'NPcll1221':1})
 
 GC_729 = Coupling(name = 'GC_729',
                   value = '(2*cHGtil*G*vevhat**2)/LambdaSMEFT**2',
@@ -2935,7 +2935,7 @@ GC_731 = Coupling(name = 'GC_731',
 
 GC_732 = Coupling(name = 'GC_732',
                   value = '(-3*cll1221*complex(0,1)*lam*vevhat**2)/LambdaSMEFT**2',
-                  order = {'NP':1,'NPcll1':1,'QED':2})
+                  order = {'NP':1,'NPcll1':1,'QED':2,'NPcll1221':1})
 
 GC_733 = Coupling(name = 'GC_733',
                   value = '-(cHDD*cth**2*ee*complex(0,1)*vevhat**2)/(12.*LambdaSMEFT**2*sth**2)',
@@ -2963,11 +2963,11 @@ GC_738 = Coupling(name = 'GC_738',
 
 GC_739 = Coupling(name = 'GC_739',
                   value = '(cll1221*ee**2*complex(0,1)*vevhat**2)/(4.*LambdaSMEFT**2*sth**2)',
-                  order = {'NP':1,'NPcll1':1,'QED':2})
+                  order = {'NP':1,'NPcll1':1,'QED':2,'NPcll1221':1})
 
 GC_740 = Coupling(name = 'GC_740',
                   value = '-(cll1221*ee**2*complex(0,1)*vevhat**2)/(2.*LambdaSMEFT**2*sth**2)',
-                  order = {'NP':1,'NPcll1':1,'QED':2})
+                  order = {'NP':1,'NPcll1':1,'QED':2,'NPcll1221':1})
 
 GC_741 = Coupling(name = 'GC_741',
                   value = '(cHbox*ee**2*complex(0,1)*vevhat**2)/(cth**2*LambdaSMEFT**2*sth**2)',
@@ -2979,7 +2979,7 @@ GC_742 = Coupling(name = 'GC_742',
 
 GC_743 = Coupling(name = 'GC_743',
                   value = '(cll1221*ee**2*complex(0,1)*vevhat**2)/(4.*cth**2*LambdaSMEFT**2*sth**2)',
-                  order = {'NP':1,'NPcll1':1,'QED':2})
+                  order = {'NP':1,'NPcll1':1,'QED':2,'NPcll1221':1})
 
 GC_744 = Coupling(name = 'GC_744',
                   value = '-(cHDD*cth**2*ee**2*complex(0,1)*vevhat**2)/(2.*LambdaSMEFT**2*sth**2)',
@@ -2991,7 +2991,7 @@ GC_745 = Coupling(name = 'GC_745',
 
 GC_746 = Coupling(name = 'GC_746',
                   value = '(cll1221*cth**2*ee**2*complex(0,1)*vevhat**2)/(2.*LambdaSMEFT**2*sth**2)',
-                  order = {'NP':1,'NPcll1':1,'QED':2})
+                  order = {'NP':1,'NPcll1':1,'QED':2,'NPcll1221':1})
 
 GC_747 = Coupling(name = 'GC_747',
                   value = '-((cHj3*ee*complex(0,1)*vevhat**2)/(LambdaSMEFT**2*sth*cmath.sqrt(2)))',
@@ -3015,7 +3015,7 @@ GC_751 = Coupling(name = 'GC_751',
 
 GC_752 = Coupling(name = 'GC_752',
                   value = '-(cll1221*ee*complex(0,1)*vevhat**2)/(4.*LambdaSMEFT**2*sth*cmath.sqrt(2))',
-                  order = {'NP':1,'NPcll1':1,'QED':1})
+                  order = {'NP':1,'NPcll1':1,'QED':1,'NPcll1221':1})
 
 GC_753 = Coupling(name = 'GC_753',
                   value = '(cHbq*ee*complex(0,1)*vevhat**2)/(2.*cth*LambdaSMEFT**2*sth)',
@@ -3043,15 +3043,15 @@ GC_758 = Coupling(name = 'GC_758',
 
 GC_759 = Coupling(name = 'GC_759',
                   value = '(cHe11*ee*complex(0,1)*vevhat**2)/(2.*cth*LambdaSMEFT**2*sth)',
-                  order = {'NP':1,'NPcHe':1,'QED':1})
+                  order = {'NP':1,'NPcHe':1,'QED':1,'NPcHe11':1})
 
 GC_760 = Coupling(name = 'GC_760',
                   value = '(cHe22*ee*complex(0,1)*vevhat**2)/(2.*cth*LambdaSMEFT**2*sth)',
-                  order = {'NP':1,'NPcHe':1,'QED':1})
+                  order = {'NP':1,'NPcHe':1,'QED':1,'NPcHe22':1})
 
 GC_761 = Coupling(name = 'GC_761',
                   value = '(cHe33*ee*complex(0,1)*vevhat**2)/(2.*cth*LambdaSMEFT**2*sth)',
-                  order = {'NP':1,'NPcHe':1,'QED':1})
+                  order = {'NP':1,'NPcHe':1,'QED':1,'NPcHe33':1})
 
 GC_762 = Coupling(name = 'GC_762',
                   value = '(cHj1*ee*complex(0,1)*vevhat**2)/(2.*cth*LambdaSMEFT**2*sth)',
@@ -3067,15 +3067,15 @@ GC_764 = Coupling(name = 'GC_764',
 
 GC_765 = Coupling(name = 'GC_765',
                   value = '(cHl111*ee*complex(0,1)*vevhat**2)/(2.*cth*LambdaSMEFT**2*sth)',
-                  order = {'NP':1,'NPcHl1':1,'QED':1})
+                  order = {'NP':1,'NPcHl1':1,'QED':1,'NPcHl111':1})
 
 GC_766 = Coupling(name = 'GC_766',
                   value = '(cHl122*ee*complex(0,1)*vevhat**2)/(2.*cth*LambdaSMEFT**2*sth)',
-                  order = {'NP':1,'NPcHl1':1,'QED':1})
+                  order = {'NP':1,'NPcHl1':1,'QED':1,'NPcHl122':1})
 
 GC_767 = Coupling(name = 'GC_767',
                   value = '(cHl133*ee*complex(0,1)*vevhat**2)/(2.*cth*LambdaSMEFT**2*sth)',
-                  order = {'NP':1,'NPcHl1':1,'QED':1})
+                  order = {'NP':1,'NPcHl1':1,'QED':1,'NPcHl133':1})
 
 GC_768 = Coupling(name = 'GC_768',
                   value = '(cHQ1*ee*complex(0,1)*vevhat**2)/(2.*cth*LambdaSMEFT**2*sth)',
@@ -3099,11 +3099,11 @@ GC_772 = Coupling(name = 'GC_772',
 
 GC_773 = Coupling(name = 'GC_773',
                   value = '-(cll1221*ee*complex(0,1)*vevhat**2)/(8.*cth*LambdaSMEFT**2*sth)',
-                  order = {'NP':1,'NPcll1':1,'QED':1})
+                  order = {'NP':1,'NPcll1':1,'QED':1,'NPcll1221':1})
 
 GC_774 = Coupling(name = 'GC_774',
                   value = '(cll1221*ee*complex(0,1)*vevhat**2)/(8.*cth*LambdaSMEFT**2*sth)',
-                  order = {'NP':1,'NPcll1':1,'QED':1})
+                  order = {'NP':1,'NPcll1':1,'QED':1,'NPcll1221':1})
 
 GC_775 = Coupling(name = 'GC_775',
                   value = '-(cHDD*cth*ee*complex(0,1)*vevhat**2)/(4.*LambdaSMEFT**2*sth)',
@@ -3131,7 +3131,7 @@ GC_780 = Coupling(name = 'GC_780',
 
 GC_781 = Coupling(name = 'GC_781',
                   value = '-(cll1221*cth*ee*complex(0,1)*vevhat**2)/(4.*LambdaSMEFT**2*sth)',
-                  order = {'NP':1,'NPcll1':1,'QED':1})
+                  order = {'NP':1,'NPcll1':1,'QED':1,'NPcll1221':1})
 
 GC_782 = Coupling(name = 'GC_782',
                   value = '(-2*cHWB*cth*ee**2*complex(0,1)*vevhat**2)/(LambdaSMEFT**2*sth)',
@@ -3143,7 +3143,7 @@ GC_783 = Coupling(name = 'GC_783',
 
 GC_784 = Coupling(name = 'GC_784',
                   value = '-((cll1221*cth*ee**2*complex(0,1)*vevhat**2)/(LambdaSMEFT**2*sth))',
-                  order = {'NP':1,'NPcll1':1,'QED':2})
+                  order = {'NP':1,'NPcll1':1,'QED':2,'NPcll1221':1})
 
 GC_785 = Coupling(name = 'GC_785',
                   value = '-(cHDD*ee*complex(0,1)*sth*vevhat**2)/(12.*cth*LambdaSMEFT**2)',
@@ -3159,15 +3159,15 @@ GC_787 = Coupling(name = 'GC_787',
 
 GC_788 = Coupling(name = 'GC_788',
                   value = '-(cll1221*ee*complex(0,1)*sth*vevhat**2)/(12.*cth*LambdaSMEFT**2)',
-                  order = {'NP':1,'NPcll1':1,'QED':1})
+                  order = {'NP':1,'NPcll1':1,'QED':1,'NPcll1221':1})
 
 GC_789 = Coupling(name = 'GC_789',
                   value = '(cll1221*ee*complex(0,1)*sth*vevhat**2)/(6.*cth*LambdaSMEFT**2)',
-                  order = {'NP':1,'NPcll1':1,'QED':1})
+                  order = {'NP':1,'NPcll1':1,'QED':1,'NPcll1221':1})
 
 GC_790 = Coupling(name = 'GC_790',
                   value = '-(cll1221*ee*complex(0,1)*sth*vevhat**2)/(4.*cth*LambdaSMEFT**2)',
-                  order = {'NP':1,'NPcll1':1,'QED':1})
+                  order = {'NP':1,'NPcll1':1,'QED':1,'NPcll1221':1})
 
 GC_791 = Coupling(name = 'GC_791',
                   value = '(6*cH*complex(0,1)*vevhat**3)/LambdaSMEFT**2',
@@ -3183,7 +3183,7 @@ GC_793 = Coupling(name = 'GC_793',
 
 GC_794 = Coupling(name = 'GC_794',
                   value = '(-3*cll1221*complex(0,1)*lam*vevhat**3)/(2.*LambdaSMEFT**2)',
-                  order = {'NP':1,'NPcll1':1,'QED':1})
+                  order = {'NP':1,'NPcll1':1,'QED':1,'NPcll1221':1})
 
 GC_795 = Coupling(name = 'GC_795',
                   value = '(cHbox*ee**2*complex(0,1)*vevhat**3)/(2.*LambdaSMEFT**2*sth**2)',
@@ -3195,7 +3195,7 @@ GC_796 = Coupling(name = 'GC_796',
 
 GC_797 = Coupling(name = 'GC_797',
                   value = '(cll1221*ee**2*complex(0,1)*vevhat**3)/(8.*LambdaSMEFT**2*sth**2)',
-                  order = {'NP':1,'NPcll1':1,'QED':1})
+                  order = {'NP':1,'NPcll1':1,'QED':1,'NPcll1221':1})
 
 GC_798 = Coupling(name = 'GC_798',
                   value = '(cHbox*ee**2*complex(0,1)*vevhat**3)/(2.*cth**2*LambdaSMEFT**2*sth**2)',
@@ -3207,7 +3207,7 @@ GC_799 = Coupling(name = 'GC_799',
 
 GC_800 = Coupling(name = 'GC_800',
                   value = '(cll1221*ee**2*complex(0,1)*vevhat**3)/(8.*cth**2*LambdaSMEFT**2*sth**2)',
-                  order = {'NP':1,'NPcll1':1,'QED':1})
+                  order = {'NP':1,'NPcll1':1,'QED':1,'NPcll1221':1})
 
 GC_801 = Coupling(name = 'GC_801',
                   value = '(-2*cHWB*complex(0,1)*vevhat)/LambdaSMEFT**2 + (4*cHWB*complex(0,1)*sth**2*vevhat)/LambdaSMEFT**2',
@@ -3355,7 +3355,7 @@ GC_836 = Coupling(name = 'GC_836',
 
 GC_837 = Coupling(name = 'GC_837',
                   value = '-(cll1221*complex(0,1)*vevhat**2*yb)/(4.*LambdaSMEFT**2*cmath.sqrt(2))',
-                  order = {'NP':1,'NPcll1':1,'QED':1})
+                  order = {'NP':1,'NPcll1':1,'QED':1,'NPcll1221':1})
 
 GC_838 = Coupling(name = 'GC_838',
                   value = '(cHl311*complex(0,1)*vevhat**2*yb)/(2.*LambdaSMEFT**2*cmath.sqrt(2)) + (cHl322*complex(0,1)*vevhat**2*yb)/(2.*LambdaSMEFT**2*cmath.sqrt(2))',
@@ -3811,7 +3811,7 @@ GC_950 = Coupling(name = 'GC_950',
 
 GC_951 = Coupling(name = 'GC_951',
                   value = '-(cll1221*complex(0,1)*vevhat**2*yc)/(4.*LambdaSMEFT**2*cmath.sqrt(2))',
-                  order = {'NP':1,'NPcll1':1,'QED':1})
+                  order = {'NP':1,'NPcll1':1,'QED':1,'NPcll1221':1})
 
 GC_952 = Coupling(name = 'GC_952',
                   value = '-((cuHIm*vevhat**2*yc)/(LambdaSMEFT**2*cmath.sqrt(2)))',
@@ -4175,7 +4175,7 @@ GC_1041 = Coupling(name = 'GC_1041',
 
 GC_1042 = Coupling(name = 'GC_1042',
                    value = '-(cll1221*complex(0,1)*vevhat**2*ydo)/(4.*LambdaSMEFT**2*cmath.sqrt(2))',
-                   order = {'NP':1,'NPcll1':1,'QED':1})
+                   order = {'NP':1,'NPcll1':1,'QED':1,'NPcll1221':1})
 
 GC_1043 = Coupling(name = 'GC_1043',
                    value = '-((cjujd11Im*yc*ydo)/LambdaSMEFT**2)',
@@ -4263,7 +4263,7 @@ GC_1063 = Coupling(name = 'GC_1063',
 
 GC_1064 = Coupling(name = 'GC_1064',
                    value = '-(cll1221*complex(0,1)*vevhat**2*ye)/(4.*LambdaSMEFT**2*cmath.sqrt(2))',
-                   order = {'NP':1,'NPcll1':1,'QED':1})
+                   order = {'NP':1,'NPcll1':1,'QED':1,'NPcll1221':1})
 
 GC_1065 = Coupling(name = 'GC_1065',
                    value = '(cHl311*complex(0,1)*vevhat**2*ye)/(2.*LambdaSMEFT**2*cmath.sqrt(2)) + (cHl322*complex(0,1)*vevhat**2*ye)/(2.*LambdaSMEFT**2*cmath.sqrt(2))',
@@ -4287,7 +4287,7 @@ GC_1069 = Coupling(name = 'GC_1069',
 
 GC_1070 = Coupling(name = 'GC_1070',
                    value = '-(cll1221*complex(0,1)*vevhat**2*ym)/(4.*LambdaSMEFT**2*cmath.sqrt(2))',
-                   order = {'NP':1,'NPcll1':1,'QED':1})
+                   order = {'NP':1,'NPcll1':1,'QED':1,'NPcll1221':1})
 
 GC_1071 = Coupling(name = 'GC_1071',
                    value = '(cHl311*complex(0,1)*vevhat**2*ym)/(2.*LambdaSMEFT**2*cmath.sqrt(2)) + (cHl322*complex(0,1)*vevhat**2*ym)/(2.*LambdaSMEFT**2*cmath.sqrt(2))',
@@ -4643,7 +4643,7 @@ GC_1158 = Coupling(name = 'GC_1158',
 
 GC_1159 = Coupling(name = 'GC_1159',
                    value = '-(cll1221*complex(0,1)*vevhat**2*ys)/(4.*LambdaSMEFT**2*cmath.sqrt(2))',
-                   order = {'NP':1,'NPcll1':1,'QED':1})
+                   order = {'NP':1,'NPcll1':1,'QED':1,'NPcll1221':1})
 
 GC_1160 = Coupling(name = 'GC_1160',
                    value = '-((cjujd11Im*yc*ys)/LambdaSMEFT**2)',
@@ -4799,7 +4799,7 @@ GC_1197 = Coupling(name = 'GC_1197',
 
 GC_1198 = Coupling(name = 'GC_1198',
                    value = '-(cll1221*complex(0,1)*vevhat**2*yt)/(4.*LambdaSMEFT**2*cmath.sqrt(2))',
-                   order = {'NP':1,'NPcll1':1,'QED':1})
+                   order = {'NP':1,'NPcll1':1,'QED':1,'NPcll1221':1})
 
 GC_1199 = Coupling(name = 'GC_1199',
                    value = '(cHl311*complex(0,1)*vevhat**2*yt)/(2.*LambdaSMEFT**2*cmath.sqrt(2)) + (cHl322*complex(0,1)*vevhat**2*yt)/(2.*LambdaSMEFT**2*cmath.sqrt(2))',
@@ -4823,7 +4823,7 @@ GC_1203 = Coupling(name = 'GC_1203',
 
 GC_1204 = Coupling(name = 'GC_1204',
                    value = '-(cll1221*complex(0,1)*vevhat**2*ytau)/(4.*LambdaSMEFT**2*cmath.sqrt(2))',
-                   order = {'NP':1,'NPcll1':1,'QED':1})
+                   order = {'NP':1,'NPcll1':1,'QED':1,'NPcll1221':1})
 
 GC_1205 = Coupling(name = 'GC_1205',
                    value = '(cHl311*complex(0,1)*vevhat**2*ytau)/(2.*LambdaSMEFT**2*cmath.sqrt(2)) + (cHl322*complex(0,1)*vevhat**2*ytau)/(2.*LambdaSMEFT**2*cmath.sqrt(2))',
@@ -5279,7 +5279,7 @@ GC_1317 = Coupling(name = 'GC_1317',
 
 GC_1318 = Coupling(name = 'GC_1318',
                    value = '-(cll1221*complex(0,1)*vevhat**2*yup)/(4.*LambdaSMEFT**2*cmath.sqrt(2))',
-                   order = {'NP':1,'NPcll1':1,'QED':1})
+                   order = {'NP':1,'NPcll1':1,'QED':1,'NPcll1221':1})
 
 GC_1319 = Coupling(name = 'GC_1319',
                    value = '-((cuHIm*vevhat**2*yup)/(LambdaSMEFT**2*cmath.sqrt(2)))',

--- a/UFO_models/SMEFTsim_top_MwScheme_UFO/couplings.py
+++ b/UFO_models/SMEFTsim_top_MwScheme_UFO/couplings.py
@@ -1431,15 +1431,15 @@ GC_355 = Coupling(name = 'GC_355',
 
 GC_356 = Coupling(name = 'GC_356',
                   value = '-((cHl311*ee*complex(0,1)*cmath.sqrt(2))/(LambdaSMEFT**2*sth))',
-                  order = {'NP':1,'NPcHl3':1,'QED':3})
+                  order = {'NP':1,'NPcHl3':1,'QED':3,'NPcHl311':1})
 
 GC_357 = Coupling(name = 'GC_357',
                   value = '-((cHl322*ee*complex(0,1)*cmath.sqrt(2))/(LambdaSMEFT**2*sth))',
-                  order = {'NP':1,'NPcHl3':1,'QED':3})
+                  order = {'NP':1,'NPcHl3':1,'QED':3,'NPcHl322':1})
 
 GC_358 = Coupling(name = 'GC_358',
                   value = '-((cHl333*ee*complex(0,1)*cmath.sqrt(2))/(LambdaSMEFT**2*sth))',
-                  order = {'NP':1,'NPcHl3':1,'QED':3})
+                  order = {'NP':1,'NPcHl3':1,'QED':3,'NPcHl333':1})
 
 GC_359 = Coupling(name = 'GC_359',
                   value = '-((cHQ3*ee*complex(0,1)*cmath.sqrt(2))/(LambdaSMEFT**2*sth))',
@@ -1503,27 +1503,27 @@ GC_373 = Coupling(name = 'GC_373',
 
 GC_374 = Coupling(name = 'GC_374',
                   value = '-((cHl311*ee*complex(0,1))/(cth*LambdaSMEFT**2*sth))',
-                  order = {'NP':1,'NPcHl3':1,'QED':3})
+                  order = {'NP':1,'NPcHl3':1,'QED':3,'NPcHl311':1})
 
 GC_375 = Coupling(name = 'GC_375',
                   value = '(cHl311*ee*complex(0,1))/(cth*LambdaSMEFT**2*sth)',
-                  order = {'NP':1,'NPcHl3':1,'QED':3})
+                  order = {'NP':1,'NPcHl3':1,'QED':3,'NPcHl311':1})
 
 GC_376 = Coupling(name = 'GC_376',
                   value = '-((cHl322*ee*complex(0,1))/(cth*LambdaSMEFT**2*sth))',
-                  order = {'NP':1,'NPcHl3':1,'QED':3})
+                  order = {'NP':1,'NPcHl3':1,'QED':3,'NPcHl322':1})
 
 GC_377 = Coupling(name = 'GC_377',
                   value = '(cHl322*ee*complex(0,1))/(cth*LambdaSMEFT**2*sth)',
-                  order = {'NP':1,'NPcHl3':1,'QED':3})
+                  order = {'NP':1,'NPcHl3':1,'QED':3,'NPcHl322':1})
 
 GC_378 = Coupling(name = 'GC_378',
                   value = '-((cHl333*ee*complex(0,1))/(cth*LambdaSMEFT**2*sth))',
-                  order = {'NP':1,'NPcHl3':1,'QED':3})
+                  order = {'NP':1,'NPcHl3':1,'QED':3,'NPcHl333':1})
 
 GC_379 = Coupling(name = 'GC_379',
                   value = '(cHl333*ee*complex(0,1))/(cth*LambdaSMEFT**2*sth)',
-                  order = {'NP':1,'NPcHl3':1,'QED':3})
+                  order = {'NP':1,'NPcHl3':1,'QED':3,'NPcHl333':1})
 
 GC_380 = Coupling(name = 'GC_380',
                   value = '(cHQ1*ee*complex(0,1))/(cth*LambdaSMEFT**2*sth)',
@@ -2503,15 +2503,15 @@ GC_623 = Coupling(name = 'GC_623',
 
 GC_624 = Coupling(name = 'GC_624',
                   value = '-((cHl311*ee*complex(0,1)*vevhat*cmath.sqrt(2))/(LambdaSMEFT**2*sth))',
-                  order = {'NP':1,'NPcHl3':1,'QED':2})
+                  order = {'NP':1,'NPcHl3':1,'QED':2,'NPcHl311':1})
 
 GC_625 = Coupling(name = 'GC_625',
                   value = '-((cHl322*ee*complex(0,1)*vevhat*cmath.sqrt(2))/(LambdaSMEFT**2*sth))',
-                  order = {'NP':1,'NPcHl3':1,'QED':2})
+                  order = {'NP':1,'NPcHl3':1,'QED':2,'NPcHl322':1})
 
 GC_626 = Coupling(name = 'GC_626',
                   value = '-((cHl333*ee*complex(0,1)*vevhat*cmath.sqrt(2))/(LambdaSMEFT**2*sth))',
-                  order = {'NP':1,'NPcHl3':1,'QED':2})
+                  order = {'NP':1,'NPcHl3':1,'QED':2,'NPcHl333':1})
 
 GC_627 = Coupling(name = 'GC_627',
                   value = '-((cHQ3*ee*complex(0,1)*vevhat*cmath.sqrt(2))/(LambdaSMEFT**2*sth))',
@@ -2575,27 +2575,27 @@ GC_641 = Coupling(name = 'GC_641',
 
 GC_642 = Coupling(name = 'GC_642',
                   value = '-((cHl311*ee*complex(0,1)*vevhat)/(cth*LambdaSMEFT**2*sth))',
-                  order = {'NP':1,'NPcHl3':1,'QED':2})
+                  order = {'NP':1,'NPcHl3':1,'QED':2,'NPcHl311':1})
 
 GC_643 = Coupling(name = 'GC_643',
                   value = '(cHl311*ee*complex(0,1)*vevhat)/(cth*LambdaSMEFT**2*sth)',
-                  order = {'NP':1,'NPcHl3':1,'QED':2})
+                  order = {'NP':1,'NPcHl3':1,'QED':2,'NPcHl311':1})
 
 GC_644 = Coupling(name = 'GC_644',
                   value = '-((cHl322*ee*complex(0,1)*vevhat)/(cth*LambdaSMEFT**2*sth))',
-                  order = {'NP':1,'NPcHl3':1,'QED':2})
+                  order = {'NP':1,'NPcHl3':1,'QED':2,'NPcHl322':1})
 
 GC_645 = Coupling(name = 'GC_645',
                   value = '(cHl322*ee*complex(0,1)*vevhat)/(cth*LambdaSMEFT**2*sth)',
-                  order = {'NP':1,'NPcHl3':1,'QED':2})
+                  order = {'NP':1,'NPcHl3':1,'QED':2,'NPcHl322':1})
 
 GC_646 = Coupling(name = 'GC_646',
                   value = '-((cHl333*ee*complex(0,1)*vevhat)/(cth*LambdaSMEFT**2*sth))',
-                  order = {'NP':1,'NPcHl3':1,'QED':2})
+                  order = {'NP':1,'NPcHl3':1,'QED':2,'NPcHl333':1})
 
 GC_647 = Coupling(name = 'GC_647',
                   value = '(cHl333*ee*complex(0,1)*vevhat)/(cth*LambdaSMEFT**2*sth)',
-                  order = {'NP':1,'NPcHl3':1,'QED':2})
+                  order = {'NP':1,'NPcHl3':1,'QED':2,'NPcHl333':1})
 
 GC_648 = Coupling(name = 'GC_648',
                   value = '(cHQ1*ee*complex(0,1)*vevhat)/(cth*LambdaSMEFT**2*sth)',
@@ -3219,35 +3219,35 @@ GC_802 = Coupling(name = 'GC_802',
 
 GC_803 = Coupling(name = 'GC_803',
                   value = '-(cHl311*ee*complex(0,1)*vevhat**2)/(6.*LambdaSMEFT**2) - (cHl322*ee*complex(0,1)*vevhat**2)/(6.*LambdaSMEFT**2)',
-                  order = {'NP':1,'NPcHl3':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'QED':1,'NPcHl311':1,'NPcHl322':1})
 
 GC_804 = Coupling(name = 'GC_804',
                   value = '(cHl311*ee*complex(0,1)*vevhat**2)/(3.*LambdaSMEFT**2) + (cHl322*ee*complex(0,1)*vevhat**2)/(3.*LambdaSMEFT**2)',
-                  order = {'NP':1,'NPcHl3':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'QED':1,'NPcHl311':1,'NPcHl322':1})
 
 GC_805 = Coupling(name = 'GC_805',
                   value = '-(cHl311*ee*complex(0,1)*vevhat**2)/(2.*LambdaSMEFT**2) - (cHl322*ee*complex(0,1)*vevhat**2)/(2.*LambdaSMEFT**2)',
-                  order = {'NP':1,'NPcHl3':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'QED':1,'NPcHl311':1,'NPcHl322':1})
 
 GC_806 = Coupling(name = 'GC_806',
                   value = '(cHl311*ee*complex(0,1)*vevhat**2)/(2.*LambdaSMEFT**2) + (cHl322*ee*complex(0,1)*vevhat**2)/(2.*LambdaSMEFT**2)',
-                  order = {'NP':1,'NPcHl3':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'QED':1,'NPcHl311':1,'NPcHl322':1})
 
 GC_807 = Coupling(name = 'GC_807',
                   value = '-((cHl311*ee**2*complex(0,1)*vevhat**2)/LambdaSMEFT**2) - (cHl322*ee**2*complex(0,1)*vevhat**2)/LambdaSMEFT**2',
-                  order = {'NP':1,'NPcHl3':1,'QED':2})
+                  order = {'NP':1,'NPcHl3':1,'QED':2,'NPcHl311':1,'NPcHl322':1})
 
 GC_808 = Coupling(name = 'GC_808',
                   value = '(6*cHl311*complex(0,1)*lam*vevhat**2)/LambdaSMEFT**2 + (6*cHl322*complex(0,1)*lam*vevhat**2)/LambdaSMEFT**2',
-                  order = {'NP':1,'NPcHl3':1,'QED':2})
+                  order = {'NP':1,'NPcHl3':1,'QED':2,'NPcHl311':1,'NPcHl322':1})
 
 GC_809 = Coupling(name = 'GC_809',
                   value = '-(cHl311*ee**2*complex(0,1)*vevhat**2)/(2.*LambdaSMEFT**2*sth**2) - (cHl322*ee**2*complex(0,1)*vevhat**2)/(2.*LambdaSMEFT**2*sth**2)',
-                  order = {'NP':1,'NPcHl3':1,'QED':2})
+                  order = {'NP':1,'NPcHl3':1,'QED':2,'NPcHl311':1,'NPcHl322':1})
 
 GC_810 = Coupling(name = 'GC_810',
                   value = '(cHl311*ee**2*complex(0,1)*vevhat**2)/(LambdaSMEFT**2*sth**2) + (cHl322*ee**2*complex(0,1)*vevhat**2)/(LambdaSMEFT**2*sth**2)',
-                  order = {'NP':1,'NPcHl3':1,'QED':2})
+                  order = {'NP':1,'NPcHl3':1,'QED':2,'NPcHl311':1,'NPcHl322':1})
 
 GC_811 = Coupling(name = 'GC_811',
                   value = '(-4*cHWB*ee**2*complex(0,1)*vevhat**2)/LambdaSMEFT**2 + (2*cHWB*ee**2*complex(0,1)*vevhat**2)/(LambdaSMEFT**2*sth**2)',
@@ -3255,55 +3255,55 @@ GC_811 = Coupling(name = 'GC_811',
 
 GC_812 = Coupling(name = 'GC_812',
                   value = '-(cHl311*ee**2*complex(0,1)*vevhat**2)/(2.*cth**2*LambdaSMEFT**2*sth**2) - (cHl322*ee**2*complex(0,1)*vevhat**2)/(2.*cth**2*LambdaSMEFT**2*sth**2)',
-                  order = {'NP':1,'NPcHl3':1,'QED':2})
+                  order = {'NP':1,'NPcHl3':1,'QED':2,'NPcHl311':1,'NPcHl322':1})
 
 GC_813 = Coupling(name = 'GC_813',
                   value = '-((cHl311*cth**2*ee**2*complex(0,1)*vevhat**2)/(LambdaSMEFT**2*sth**2)) - (cHl322*cth**2*ee**2*complex(0,1)*vevhat**2)/(LambdaSMEFT**2*sth**2)',
-                  order = {'NP':1,'NPcHl3':1,'QED':2})
+                  order = {'NP':1,'NPcHl3':1,'QED':2,'NPcHl311':1,'NPcHl322':1})
 
 GC_814 = Coupling(name = 'GC_814',
                   value = '(cHl311*ee*complex(0,1)*vevhat**2)/(2.*LambdaSMEFT**2*sth*cmath.sqrt(2)) - (cHl322*ee*complex(0,1)*vevhat**2)/(2.*LambdaSMEFT**2*sth*cmath.sqrt(2))',
-                  order = {'NP':1,'NPcHl3':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'QED':1,'NPcHl311':1,'NPcHl322':1})
 
 GC_815 = Coupling(name = 'GC_815',
                   value = '-(cHl311*ee*complex(0,1)*vevhat**2)/(2.*LambdaSMEFT**2*sth*cmath.sqrt(2)) + (cHl322*ee*complex(0,1)*vevhat**2)/(2.*LambdaSMEFT**2*sth*cmath.sqrt(2))',
-                  order = {'NP':1,'NPcHl3':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'QED':1,'NPcHl311':1,'NPcHl322':1})
 
 GC_816 = Coupling(name = 'GC_816',
                   value = '(cHl311*ee*complex(0,1)*vevhat**2)/(2.*LambdaSMEFT**2*sth*cmath.sqrt(2)) + (cHl322*ee*complex(0,1)*vevhat**2)/(2.*LambdaSMEFT**2*sth*cmath.sqrt(2))',
-                  order = {'NP':1,'NPcHl3':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'QED':1,'NPcHl311':1,'NPcHl322':1})
 
 GC_817 = Coupling(name = 'GC_817',
                   value = '(cHl311*ee*complex(0,1)*vevhat**2)/(2.*LambdaSMEFT**2*sth*cmath.sqrt(2)) + (cHl322*ee*complex(0,1)*vevhat**2)/(2.*LambdaSMEFT**2*sth*cmath.sqrt(2)) - (cHl333*ee*complex(0,1)*vevhat**2)/(LambdaSMEFT**2*sth*cmath.sqrt(2))',
-                  order = {'NP':1,'NPcHl3':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'QED':1,'NPcHl311':1,'NPcHl322':1,'NPcHl333':1})
 
 GC_818 = Coupling(name = 'GC_818',
                   value = '-(cHl311*ee*complex(0,1)*vevhat**2)/(4.*cth*LambdaSMEFT**2*sth) - (cHl322*ee*complex(0,1)*vevhat**2)/(4.*cth*LambdaSMEFT**2*sth)',
-                  order = {'NP':1,'NPcHl3':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'QED':1,'NPcHl311':1,'NPcHl322':1})
 
 GC_819 = Coupling(name = 'GC_819',
                   value = '(cHl311*ee*complex(0,1)*vevhat**2)/(4.*cth*LambdaSMEFT**2*sth) - (cHl322*ee*complex(0,1)*vevhat**2)/(4.*cth*LambdaSMEFT**2*sth)',
-                  order = {'NP':1,'NPcHl3':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'QED':1,'NPcHl311':1,'NPcHl322':1})
 
 GC_820 = Coupling(name = 'GC_820',
                   value = '-(cHl311*ee*complex(0,1)*vevhat**2)/(4.*cth*LambdaSMEFT**2*sth) + (cHl322*ee*complex(0,1)*vevhat**2)/(4.*cth*LambdaSMEFT**2*sth)',
-                  order = {'NP':1,'NPcHl3':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'QED':1,'NPcHl311':1,'NPcHl322':1})
 
 GC_821 = Coupling(name = 'GC_821',
                   value = '(cHl311*ee*complex(0,1)*vevhat**2)/(4.*cth*LambdaSMEFT**2*sth) + (cHl322*ee*complex(0,1)*vevhat**2)/(4.*cth*LambdaSMEFT**2*sth)',
-                  order = {'NP':1,'NPcHl3':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'QED':1,'NPcHl311':1,'NPcHl322':1})
 
 GC_822 = Coupling(name = 'GC_822',
                   value = '(cHl311*ee*complex(0,1)*vevhat**2)/(4.*cth*LambdaSMEFT**2*sth) + (cHl322*ee*complex(0,1)*vevhat**2)/(4.*cth*LambdaSMEFT**2*sth) - (cHl333*ee*complex(0,1)*vevhat**2)/(2.*cth*LambdaSMEFT**2*sth)',
-                  order = {'NP':1,'NPcHl3':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'QED':1,'NPcHl311':1,'NPcHl322':1,'NPcHl333':1})
 
 GC_823 = Coupling(name = 'GC_823',
                   value = '-(cHl311*ee*complex(0,1)*vevhat**2)/(4.*cth*LambdaSMEFT**2*sth) - (cHl322*ee*complex(0,1)*vevhat**2)/(4.*cth*LambdaSMEFT**2*sth) + (cHl333*ee*complex(0,1)*vevhat**2)/(2.*cth*LambdaSMEFT**2*sth)',
-                  order = {'NP':1,'NPcHl3':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'QED':1,'NPcHl311':1,'NPcHl322':1,'NPcHl333':1})
 
 GC_824 = Coupling(name = 'GC_824',
                   value = '(cHl311*cth*ee*complex(0,1)*vevhat**2)/(2.*LambdaSMEFT**2*sth) + (cHl322*cth*ee*complex(0,1)*vevhat**2)/(2.*LambdaSMEFT**2*sth)',
-                  order = {'NP':1,'NPcHl3':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'QED':1,'NPcHl311':1,'NPcHl322':1})
 
 GC_825 = Coupling(name = 'GC_825',
                   value = '(cHDD*cth*ee**2*complex(0,1)*vevhat**2)/(2.*LambdaSMEFT**2*sth**3) - (cHDD*cth*ee**2*complex(0,1)*vevhat**2)/(LambdaSMEFT**2*sth)',
@@ -3311,31 +3311,31 @@ GC_825 = Coupling(name = 'GC_825',
 
 GC_826 = Coupling(name = 'GC_826',
                   value = '(2*cHl311*cth*ee**2*complex(0,1)*vevhat**2)/(LambdaSMEFT**2*sth) + (2*cHl322*cth*ee**2*complex(0,1)*vevhat**2)/(LambdaSMEFT**2*sth)',
-                  order = {'NP':1,'NPcHl3':1,'QED':2})
+                  order = {'NP':1,'NPcHl3':1,'QED':2,'NPcHl311':1,'NPcHl322':1})
 
 GC_827 = Coupling(name = 'GC_827',
                   value = '(cHl311*ee*complex(0,1)*sth*vevhat**2)/(6.*cth*LambdaSMEFT**2) + (cHl322*ee*complex(0,1)*sth*vevhat**2)/(6.*cth*LambdaSMEFT**2)',
-                  order = {'NP':1,'NPcHl3':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'QED':1,'NPcHl311':1,'NPcHl322':1})
 
 GC_828 = Coupling(name = 'GC_828',
                   value = '-(cHl311*ee*complex(0,1)*sth*vevhat**2)/(3.*cth*LambdaSMEFT**2) - (cHl322*ee*complex(0,1)*sth*vevhat**2)/(3.*cth*LambdaSMEFT**2)',
-                  order = {'NP':1,'NPcHl3':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'QED':1,'NPcHl311':1,'NPcHl322':1})
 
 GC_829 = Coupling(name = 'GC_829',
                   value = '(cHl311*ee*complex(0,1)*sth*vevhat**2)/(2.*cth*LambdaSMEFT**2) + (cHl322*ee*complex(0,1)*sth*vevhat**2)/(2.*cth*LambdaSMEFT**2)',
-                  order = {'NP':1,'NPcHl3':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'QED':1,'NPcHl311':1,'NPcHl322':1})
 
 GC_830 = Coupling(name = 'GC_830',
                   value = '(3*cHl311*complex(0,1)*lam*vevhat**3)/LambdaSMEFT**2 + (3*cHl322*complex(0,1)*lam*vevhat**3)/LambdaSMEFT**2',
-                  order = {'NP':1,'NPcHl3':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'QED':1,'NPcHl311':1,'NPcHl322':1})
 
 GC_831 = Coupling(name = 'GC_831',
                   value = '-(cHl311*ee**2*complex(0,1)*vevhat**3)/(4.*LambdaSMEFT**2*sth**2) - (cHl322*ee**2*complex(0,1)*vevhat**3)/(4.*LambdaSMEFT**2*sth**2)',
-                  order = {'NP':1,'NPcHl3':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'QED':1,'NPcHl311':1,'NPcHl322':1})
 
 GC_832 = Coupling(name = 'GC_832',
                   value = '-(cHl311*ee**2*complex(0,1)*vevhat**3)/(4.*cth**2*LambdaSMEFT**2*sth**2) - (cHl322*ee**2*complex(0,1)*vevhat**3)/(4.*cth**2*LambdaSMEFT**2*sth**2)',
-                  order = {'NP':1,'NPcHl3':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'QED':1,'NPcHl311':1,'NPcHl322':1})
 
 GC_833 = Coupling(name = 'GC_833',
                   value = '-((complex(0,1)*yb)/cmath.sqrt(2))',
@@ -3359,7 +3359,7 @@ GC_837 = Coupling(name = 'GC_837',
 
 GC_838 = Coupling(name = 'GC_838',
                   value = '(cHl311*complex(0,1)*vevhat**2*yb)/(2.*LambdaSMEFT**2*cmath.sqrt(2)) + (cHl322*complex(0,1)*vevhat**2*yb)/(2.*LambdaSMEFT**2*cmath.sqrt(2))',
-                  order = {'NP':1,'NPcHl3':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'QED':1,'NPcHl311':1,'NPcHl322':1})
 
 GC_839 = Coupling(name = 'GC_839',
                   value = '-((complex(0,1)*yc)/cmath.sqrt(2))',
@@ -3823,7 +3823,7 @@ GC_953 = Coupling(name = 'GC_953',
 
 GC_954 = Coupling(name = 'GC_954',
                   value = '(cHl311*complex(0,1)*vevhat**2*yc)/(2.*LambdaSMEFT**2*cmath.sqrt(2)) + (cHl322*complex(0,1)*vevhat**2*yc)/(2.*LambdaSMEFT**2*cmath.sqrt(2))',
-                  order = {'NP':1,'NPcHl3':1,'QED':1})
+                  order = {'NP':1,'NPcHl3':1,'QED':1,'NPcHl311':1,'NPcHl322':1})
 
 GC_955 = Coupling(name = 'GC_955',
                   value = '-((complex(0,1)*ydo)/cmath.sqrt(2))',
@@ -4243,7 +4243,7 @@ GC_1058 = Coupling(name = 'GC_1058',
 
 GC_1059 = Coupling(name = 'GC_1059',
                    value = '(cHl311*complex(0,1)*vevhat**2*ydo)/(2.*LambdaSMEFT**2*cmath.sqrt(2)) + (cHl322*complex(0,1)*vevhat**2*ydo)/(2.*LambdaSMEFT**2*cmath.sqrt(2))',
-                   order = {'NP':1,'NPcHl3':1,'QED':1})
+                   order = {'NP':1,'NPcHl3':1,'QED':1,'NPcHl311':1,'NPcHl322':1})
 
 GC_1060 = Coupling(name = 'GC_1060',
                    value = '-((complex(0,1)*ye)/cmath.sqrt(2))',
@@ -4267,7 +4267,7 @@ GC_1064 = Coupling(name = 'GC_1064',
 
 GC_1065 = Coupling(name = 'GC_1065',
                    value = '(cHl311*complex(0,1)*vevhat**2*ye)/(2.*LambdaSMEFT**2*cmath.sqrt(2)) + (cHl322*complex(0,1)*vevhat**2*ye)/(2.*LambdaSMEFT**2*cmath.sqrt(2))',
-                   order = {'NP':1,'NPcHl3':1,'QED':1})
+                   order = {'NP':1,'NPcHl3':1,'QED':1,'NPcHl311':1,'NPcHl322':1})
 
 GC_1066 = Coupling(name = 'GC_1066',
                    value = '-((complex(0,1)*ym)/cmath.sqrt(2))',
@@ -4291,7 +4291,7 @@ GC_1070 = Coupling(name = 'GC_1070',
 
 GC_1071 = Coupling(name = 'GC_1071',
                    value = '(cHl311*complex(0,1)*vevhat**2*ym)/(2.*LambdaSMEFT**2*cmath.sqrt(2)) + (cHl322*complex(0,1)*vevhat**2*ym)/(2.*LambdaSMEFT**2*cmath.sqrt(2))',
-                   order = {'NP':1,'NPcHl3':1,'QED':1})
+                   order = {'NP':1,'NPcHl3':1,'QED':1,'NPcHl311':1,'NPcHl322':1})
 
 GC_1072 = Coupling(name = 'GC_1072',
                    value = '-((complex(0,1)*ys)/cmath.sqrt(2))',
@@ -4771,7 +4771,7 @@ GC_1190 = Coupling(name = 'GC_1190',
 
 GC_1191 = Coupling(name = 'GC_1191',
                    value = '(cHl311*complex(0,1)*vevhat**2*ys)/(2.*LambdaSMEFT**2*cmath.sqrt(2)) + (cHl322*complex(0,1)*vevhat**2*ys)/(2.*LambdaSMEFT**2*cmath.sqrt(2))',
-                   order = {'NP':1,'NPcHl3':1,'QED':1})
+                   order = {'NP':1,'NPcHl3':1,'QED':1,'NPcHl311':1,'NPcHl322':1})
 
 GC_1192 = Coupling(name = 'GC_1192',
                    value = '-((complex(0,1)*yt)/cmath.sqrt(2))',
@@ -4803,7 +4803,7 @@ GC_1198 = Coupling(name = 'GC_1198',
 
 GC_1199 = Coupling(name = 'GC_1199',
                    value = '(cHl311*complex(0,1)*vevhat**2*yt)/(2.*LambdaSMEFT**2*cmath.sqrt(2)) + (cHl322*complex(0,1)*vevhat**2*yt)/(2.*LambdaSMEFT**2*cmath.sqrt(2))',
-                   order = {'NP':1,'NPcHl3':1,'QED':1})
+                   order = {'NP':1,'NPcHl3':1,'QED':1,'NPcHl311':1,'NPcHl322':1})
 
 GC_1200 = Coupling(name = 'GC_1200',
                    value = '-((complex(0,1)*ytau)/cmath.sqrt(2))',
@@ -4827,7 +4827,7 @@ GC_1204 = Coupling(name = 'GC_1204',
 
 GC_1205 = Coupling(name = 'GC_1205',
                    value = '(cHl311*complex(0,1)*vevhat**2*ytau)/(2.*LambdaSMEFT**2*cmath.sqrt(2)) + (cHl322*complex(0,1)*vevhat**2*ytau)/(2.*LambdaSMEFT**2*cmath.sqrt(2))',
-                   order = {'NP':1,'NPcHl3':1,'QED':1})
+                   order = {'NP':1,'NPcHl3':1,'QED':1,'NPcHl311':1,'NPcHl322':1})
 
 GC_1206 = Coupling(name = 'GC_1206',
                    value = '-((complex(0,1)*yup)/cmath.sqrt(2))',
@@ -5479,5 +5479,6 @@ GC_1367 = Coupling(name = 'GC_1367',
 
 GC_1368 = Coupling(name = 'GC_1368',
                    value = '(cHl311*complex(0,1)*vevhat**2*yup)/(2.*LambdaSMEFT**2*cmath.sqrt(2)) + (cHl322*complex(0,1)*vevhat**2*yup)/(2.*LambdaSMEFT**2*cmath.sqrt(2))',
-                   order = {'NP':1,'NPcHl3':1,'QED':1})
+                   order = {'NP':1,'NPcHl3':1,'QED':1,'NPcHl311':1,'NPcHl322':1})
+
 


### PR DESCRIPTION
This commit allows to include dedicated flavour specific NP tags in the squared order syntax.

For instance, to derive the cross-term of ```cHe11``` and ```cHe22```, the following squared order syntax can be used,
```
NPcHe11^2==1 NPcHe22^2==1 NP^2===2
```
Parameter groups with the syntax enabled
- [x] cll
- [x] cHe
- [x] cHl3
- [x] cHl1 